### PR TITLE
validate provided network id

### DIFF
--- a/src/main/python/clc_ansible_module/clc_server.py
+++ b/src/main/python/clc_ansible_module/clc_server.py
@@ -881,6 +881,10 @@ class ClcServer:
         :return: a valid network id
         """
         network_id = module.params.get('network_id')
+        # Validates provided network id
+        # Allows lookup of network by id, name, or cidr notation
+        if network_id:
+          network_id = datacenter.Networks().Get(network_id).id
 
         if not network_id:
             try:

--- a/src/main/python/clc_ansible_module/clc_server.py
+++ b/src/main/python/clc_ansible_module/clc_server.py
@@ -884,7 +884,7 @@ class ClcServer:
         # Validates provided network id
         # Allows lookup of network by id, name, or cidr notation
         if network_id:
-          network_id = datacenter.Networks().Get(network_id).id
+          network_id = datacenter.Networks(forced_load=True).Get(network_id).id
 
         if not network_id:
             try:

--- a/src/unittest/python/test_clc_server.py
+++ b/src/unittest/python/test_clc_server.py
@@ -739,6 +739,22 @@ class TestClcServerFunctions(unittest.TestCase):
         self.assertEqual(result, mock_network.id)
         self.assertEqual(self.module.fail_json.called, False)
 
+    def test_find_network_id_by_id(self):
+        # Setup
+        mock_network = mock.MagicMock()
+        mock_network.id = UUID('12345678123456781234567812345678')
+        self.module.params = {"network_id": "AwesomeIdHere"}
+        self.datacenter.Networks().Get = mock.MagicMock(return_value=mock_network)
+
+        # Function Under Test
+        result = ClcServer._find_network_id(self.module, self.datacenter)
+
+        # Assert Result
+        self.datacenter.Networks().Get.assert_called_once_with('AwesomeIdHere')
+        self.assertEqual(result, mock_network.id)
+        self.assertEqual(self.module.fail_json.called, False)  
+
+
     def test_find_network_id_not_found(self):
         # Setup
         self.datacenter.Networks = mock.MagicMock(side_effect=clc_sdk.CLCException("Network not found"))
@@ -1086,7 +1102,7 @@ class TestClcServerFunctions(unittest.TestCase):
         clc_server.main()
 
         mock_ClcServer.assert_called_once_with(mock_AnsibleModule_instance)
-        mock_ClcServer_instance.process_request.assert_called_once
+        assert mock_ClcServer_instance.process_request.call_count == 1
 
     @patch.object(ClcServer, '_wait_for_requests')
     @patch.object(ClcServer, '_create_clc_server')

--- a/src/unittest/python/test_clc_server.py
+++ b/src/unittest/python/test_clc_server.py
@@ -750,6 +750,7 @@ class TestClcServerFunctions(unittest.TestCase):
         result = ClcServer._find_network_id(self.module, self.datacenter)
 
         # Assert Result
+        self.datacenter.Networks.assert_called_with(forced_load=True)
         self.datacenter.Networks().Get.assert_called_once_with('AwesomeIdHere')
         self.assertEqual(result, mock_network.id)
         self.assertEqual(self.module.fail_json.called, False)  


### PR DESCRIPTION
Replaces the current behavior of blindly accepting user network_id input by doing a lookup on the provided id.  This will (eventually) allow for users to provide a network id, name, or cidr designation to create a server.  

The CIDR notation stuff is dependent on [this pull request](https://github.com/CenturyLinkCloud/clc-python-sdk/pull/23) being accepted and released.  The change will work for network id and name without the pull request.
