### PR TITLE
update server name validation logic to match Control

### DIFF
--- a/src/main/python/clc_ansible_module/clc_server.py
+++ b/src/main/python/clc_ansible_module/clc_server.py
@@ -727,11 +727,14 @@ class ClcServer:
         params = module.params
         datacenter = ClcServer._find_datacenter(clc, module)
 
+        # Grab the alias so that we can properly validate server name
+        alias = ClcServer._find_alias(clc, module)
+
         ClcServer._validate_types(module)
-        ClcServer._validate_name(module)
+        ClcServer._validate_name(module, alias)
         ClcServer._validate_counts(module)
 
-        params['alias'] = ClcServer._find_alias(clc, module)
+        params['alias'] = alias
         params['cpu'] = ClcServer._find_cpu(clc, module)
         params['memory'] = ClcServer._find_memory(clc, module)
         params['description'] = ClcServer._find_description(module)
@@ -868,7 +871,7 @@ class ClcServer:
                     msg=str("Hyperscale VMs must have storage_type = 'hyperscale'"))
 
     @staticmethod
-    def _validate_name(module):
+    def _validate_name(module, alias):
         """
         Validate that name is the correct length if provided, fail if it's not
         :param module: the module to validate
@@ -878,7 +881,7 @@ class ClcServer:
         state = module.params.get('state')
 
         if state == 'present' and (
-                len(server_name) < 1 or len(server_name) > 6):
+                len(server_name) < 1 or (len(server_name) + len(alias)) > 10):
             module.fail_json(msg=str(
                 "When state = 'present', name must be a string with a minimum length of 1 and a maximum length of 6"))
 

--- a/src/main/python/clc_ansible_module/clc_server.py
+++ b/src/main/python/clc_ansible_module/clc_server.py
@@ -883,7 +883,7 @@ class ClcServer:
         if state == 'present' and (
                 len(server_name) < 1 or (len(server_name) + len(alias)) > 10):
             module.fail_json(msg=str(
-                "When state = 'present', name must be a string with a minimum length of 1 and a maximum length of 6"))
+                "When state = 'present', length of account alias + name must be a string with a minimum length of 1 and a maximum length of 10"))
 
     @staticmethod
     def _validate_counts(module):

--- a/src/unittest/python/test_clc_server.py
+++ b/src/unittest/python/test_clc_server.py
@@ -839,10 +839,10 @@ class TestClcServerFunctions(unittest.TestCase):
 
     def test_validate_name(self):
         # Setup
-        self.module.params = {"name": "MyName", "state": "present"}  # Name is 6 Characters - Pass
+        self.module.params = {"name": "MyName", "state": "present"}  # Name is <=6 Characters - Pass
 
         # Function Under Test
-        ClcServer._validate_name(self.module)
+        ClcServer._validate_name(self.module, 'aa')
 
         # Assert Result
         self.assertEqual(self.module.fail_json.called, False)
@@ -852,7 +852,7 @@ class TestClcServerFunctions(unittest.TestCase):
         self.module.params = {"name": "MyNameIsTooLong", "state": "present"}  # Name is >6 Characters - Fail
 
         # Function Under Test
-        result = ClcServer._validate_name(self.module)
+        result = ClcServer._validate_name(self.module, 'hi')
 
         # Assert Result
         self.assertEqual(self.module.fail_json.called, True)
@@ -862,7 +862,37 @@ class TestClcServerFunctions(unittest.TestCase):
         self.module.params = {"name": "", "state": "present"}  # Name is <1 Characters - Fail
 
         # Function Under Test
-        result = ClcServer._validate_name(self.module)
+        result = ClcServer._validate_name(self.module, 'n/a')
+
+        # Assert Result
+        self.assertEqual(self.module.fail_json.called, True)
+
+    def test_validate_name_acct_alias_2_server_name_8(self):
+        # Setup
+        self.module.params = {"name": "12345678", "state": "present"}  # AA = 2 chars; name = 8 chars -> pass
+
+        # Function Under Test
+        result = ClcServer._validate_name(self.module, "AB")
+
+        # Assert Result
+        self.assertEqual(self.module.fail_json.called, False)
+
+    def test_validate_name_acct_alias_3_server_name_7(self):
+        # Setup
+        self.module.params = {"name": "1234567", "state": "present"}  # AA = 3 chars; name = 7 chars -> pass
+
+        # Function Under Test
+        result = ClcServer._validate_name(self.module, "ABC")
+
+        # Assert Result
+        self.assertEqual(self.module.fail_json.called, False)
+
+    def test_validate_name_acct_alias_6_server_name_5(self):
+        # Setup
+        self.module.params = {"name": "12345", "state": "present"}  # AA = 6 chars; name = 5 chars -> fail
+
+        # Function Under Test
+        result = ClcServer._validate_name(self.module, "ABCDEF")
 
         # Assert Result
         self.assertEqual(self.module.fail_json.called, True)


### PR DESCRIPTION
The current clc-ansible-module server name validation is hard-coded to reject server names that are not >1 char or <=6 chars.  This does not accurately represent Control logic, which determines maximum server name length based on a combination of account alias + name.  

This pull request updates name validation to match Control.  The failure message has been updated to reflect why the request was rejected.  I've added a few unit tests to cover various validation scenarios.  The lookup of the account alias in _validate_module_params needed to be moved to before the name validation to ensure the alias was present.
