### PR TITLE
capability to add source restrictions with clc_publicip module

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ Creates a public ip on an existing server or servers.
         server_ids:
             - UC1ACCTSRVR01
             - UC1ACCTSRVR02
+        source_restrictions:
+            - 1.1.1.0/24
+            - 2.2.2.0/32
         state: present
       register: clc
 
@@ -392,6 +395,7 @@ Creates a public ip on an existing server or servers.
 | `protocol:` | N |TCP | | The Protocol that the public IP will listen for |
 | `ports:` | Y | | | A list of ports to expose|
 | `server_ids:` | Y |  |  | A list of servers to create public ips on. |
+| `source_restrictions:` | N |  |  | A list of IP range allowed to access the public IP which is specified using CIDR notation. |
 | `state:` | N | `present` | `present`,`absent` | Determine whether to create or delete public IPs.  If `present` module will not create a second public ip if one already exists. |
 | `wait:` | N | True | Boolean| Whether to wait for the tasks to finish before returning. |
 

--- a/example-playbooks/example_clc_publicip_playbook.yml
+++ b/example-playbooks/example_clc_publicip_playbook.yml
@@ -23,7 +23,10 @@
         ports:
             - 80
         server_ids:
-            - UC1WFADTST01
-            - UC1WFADTST02
+            - UC1WFADTEST01
+            - UC1WFADTEST02
+        source_restrictions:
+            - 70.100.60.140/32
+            - 71.100.60.0/24
         state: present
       register: clc

--- a/src/unittest/python/test_clc_publicip.py
+++ b/src/unittest/python/test_clc_publicip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright 2015 CenturyLink
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -314,6 +314,21 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         self.module.check_mode = False
         under_test = ClcPublicIp(self.module)
         under_test.ensure_public_ip_present(server_ids, protocol, ports)
+        self.assertFalse(self.module.fail_json.called)
+
+    @patch.object(ClcPublicIp, '_get_servers_from_clc')
+    def test_ensure_server_publicip_present_w_mock_server_restrictions(self,mock_get_servers):
+        server_ids = ['TESTSVR1']
+        mock_get_servers.return_value=[mock.MagicMock()]
+        protocol = 'TCP'
+        ports = [80]
+        restrictions = ['1.1.1.1/24', '2.2.2.0/36']
+        self.module.check_mode = False
+        under_test = ClcPublicIp(self.module)
+        under_test.ensure_public_ip_present(server_ids=server_ids,
+                                            protocol=protocol,
+                                            ports=ports,
+                                            source_restrictions=restrictions)
         self.assertFalse(self.module.fail_json.called)
 
     @patch.object(ClcPublicIp, '_get_servers_from_clc')


### PR DESCRIPTION
Added the ability to pass source_restrictions as an additional optional argument with clc_public_ip module.
Sample

---
- name: Add Public IP to Server
  hosts: localhost
  gather_facts: False
  connection: local
  tasks:
  - name: Create Public IP For Servers
    clc_publicip:
      protocol: 'TCP'
      ports:
          - 80
      server_ids:
          - UC1WFADTEST01
          - UC1WFADTEST02
      source_restrictions:
          - 70.100.60.140/32
          - 71.100.60.0/24
      state: present
    register: clc
