### PR TITLE
Remove NIC Implementation

### DIFF
--- a/example-playbooks/example_clc_modify_server_remove_nic_playbook.yml
+++ b/example-playbooks/example_clc_modify_server_remove_nic_playbook.yml
@@ -1,0 +1,30 @@
+# Copyright 2015 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: modify clc server remove nic example
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: add additional network
+      clc_modify_server:
+        server_ids:
+            - UC1WFADTEST01
+            - UC1WFADTEST02
+        additional_network: 'IT Network'
+        state: 'absent'
+      register: clc
+
+    - name: debug
+      debug: var=clc.server_ids

--- a/src/main/python/clc_ansible_module/clc_modify_server.py
+++ b/src/main/python/clc_ansible_module/clc_modify_server.py
@@ -547,6 +547,9 @@ class ClcModifyServer:
                 ap_changed = self._ensure_alert_policy_absent(
                     server,
                     server_params)
+                nic_changed = self._ensure_nic_absent(
+                    server,
+                    server_params)
             if server_changed or aa_changed or ap_changed or nic_changed:
                 changed_servers.append(server)
                 changed = True
@@ -634,7 +637,7 @@ class ClcModifyServer:
         acct_alias = clc.v2.Account.GetAlias()
         datacenter = ClcModifyServer._find_datacenter(clc, module)
         additional_network = ClcModifyServer._find_network_id(module, datacenter)
-        wait = module.params.get('wait')
+        wait = module.params.get('wait', False)
         if not module.check_mode:
             try:
                 if wait:
@@ -653,6 +656,32 @@ class ClcModifyServer:
                         msg='Unable to update the server configuration for server : "{0}". {1}'.format(
                             server_id, str(ex.response_text)))
         return result
+
+    @staticmethod
+    def _modify_remove_nic(clc, module, server_id):
+      result = None
+
+      acct_alias = clc.v2.Account.GetAlias()
+      dc = ClcModifyServer._find_datacenter(clc, module)
+      network = ClcModifyServer._find_network_id(module, dc)
+      wait = module.params.get('wait', False)
+
+      if not module.check_mode:
+        try:
+          if wait:
+            clc.v2.Server(alias=acct_alias, id=server_id).RemoveNIC(network_id=network).WaitUntilComplete()
+            result = True
+          else:
+            clc.v2.Server(alias=acct_alias, id=server_id).RemoveNIC(network_id=network)
+            result = True
+        except CLCException as ex:
+          result = False
+          module.fail_json(
+            msg='Unable to remove NIC from server : "{0}". {1}'.format(
+                    server_id, str(ex.message))
+          )
+
+      return result
 
     @staticmethod
     def _find_datacenter(clc, module):
@@ -732,6 +761,25 @@ class ClcModifyServer:
                     server.id)
                 changed = add_nic
         return changed
+
+    def _ensure_nic_absent(self, server, server_params):
+      """
+
+      :param server: server from which to remove nic
+      :param server_params: map of server params
+      :return: True or False
+      """
+      changed = False
+
+      additional_network = server_params.get('additional_network', False)
+      if additional_network:
+        if not self.module.check_mode:
+          changed = self._modify_remove_nic(
+            self.clc
+            , self.module
+            , server.id)
+
+      return changed
 
     @staticmethod
     def _wait_for_requests(module, request_list):

--- a/src/main/python/clc_ansible_module/clc_modify_server.py
+++ b/src/main/python/clc_ansible_module/clc_modify_server.py
@@ -434,6 +434,7 @@ class ClcModifyServer:
         argument_spec = dict(
             server_ids=dict(type='list', required=True),
             state=dict(default='present', choices=['present', 'absent']),
+            location=dict(),
             cpu=dict(),
             memory=dict(),
             anti_affinity_policy_id=dict(),

--- a/src/main/python/clc_ansible_module/clc_modify_server.py
+++ b/src/main/python/clc_ansible_module/clc_modify_server.py
@@ -131,6 +131,14 @@ EXAMPLES = '''
     additional_network: 613a25aff2124d10a71b16cd6fb28975
     state: present
 
+- name: remove a secondary nic
+  clc_modify_server:
+    server_ids:
+        - UC1TESTSVR01
+        - UC1TESTSVR02
+    additional_network: '10.11.12.0/24'
+    state: absent
+
 - name: set the anti affinity policy on a server
   clc_modify_server:
     server_ids:

--- a/src/unittest/python/test_clc_modify_server.py
+++ b/src/unittest/python/test_clc_modify_server.py
@@ -989,5 +989,18 @@ class TestClcModifyServerFunctions(unittest.TestCase):
         under_test._modify_add_nic(self.clc, self.module, 'server_id')
         self.assertEqual(self.module.fail_json.called, False)
 
+
+    @patch.object(ClcModifyServer, '_find_network_id')
+    def test_modify_add_nic_looks_up_datacenter_by_location(self, mock_network):
+        self.module.clc = self.clc
+        self.module.params = {
+            'location': 'cybertron'
+        }
+        under_test = ClcModifyServer(self.module)
+        under_test._modify_add_nic(self.clc, self.module, 'server_id')
+
+        self.clc.v2.Datacenter.assert_called_once_with('cybertron')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/unittest/python/test_clc_modify_server.py
+++ b/src/unittest/python/test_clc_modify_server.py
@@ -30,6 +30,7 @@ class TestClcModifyServerFunctions(unittest.TestCase):
     def setUp(self):
         self.clc = mock.MagicMock()
         self.module = mock.MagicMock()
+        self.module.check_mode = False
         self.datacenter = mock.MagicMock()
 
     def test_clc_module_not_found(self):
@@ -959,7 +960,7 @@ class TestClcModifyServerFunctions(unittest.TestCase):
 
     @patch.object(ClcModifyServer, '_modify_add_nic')
     def test_ensure_nic_present_change(self, add_nic):
-        add_nic.return_value = 0
+        add_nic.return_value = True
         mock_server = mock.MagicMock()
         mock_server_params = {
             'additional_network': 'test'
@@ -970,7 +971,7 @@ class TestClcModifyServerFunctions(unittest.TestCase):
 
     @patch.object(ClcModifyServer, '_modify_add_nic')
     def test_ensure_nic_present_no_change(self, add_nic):
-        add_nic.return_value = 1
+        add_nic.return_value = False
         mock_server = mock.MagicMock()
         mock_server_params = {
             'additional_network': 'test'


### PR DESCRIPTION
1. Adds implementation for secondary nic removal (requires code in PR https://github.com/CenturyLinkCloud/clc-python-sdk/pull/30)
2. Adds all appropriate 'remove nic' examples
3. Fixes bug with missing location attribute (read: secondary nic modifications could only be performed in your 'home' datacenter)
4. General test cleanup
