### PR TITLE
Create CLC Ansible Module Base Class

### DIFF
--- a/src/main/python/clc_ansible_module/clc_aa_policy.py
+++ b/src/main/python/clc_ansible_module/clc_aa_policy.py
@@ -9,21 +9,21 @@
 # by the Workflow as a Service Team
 #
 # Copyright 2015 CenturyLink
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# CenturyLink Cloud: http://www.CenturyLinkCloud.com
-# API Documentation: https://www.centurylinkcloud.com/api-docs/v2/
+# CenturyLink Cloud: http://www.ctl.io
+# API Documentation: https://www.ctl.io/api-docs/v2/
 
 DOCUMENTATION = '''
 module: clc_aa_policy
@@ -141,52 +141,18 @@ policy:
 
 __version__ = '${version}'
 
-from distutils.version import LooseVersion
-
-try:
-    import requests
-except ImportError:
-    REQUESTS_FOUND = False
-else:
-    REQUESTS_FOUND = True
-
 #
 #  Requires the clc-python-sdk.
 #  sudo pip install clc-sdk
 #
-try:
-    import clc as clc_sdk
-    from clc import CLCException
-except ImportError:
-    CLC_FOUND = False
-    clc_sdk = None
-else:
-    CLC_FOUND = True
+import clc_ansible_module as module_base
+import clc as clc_sdk
+from clc import CLCException
 
-
-class ClcAntiAffinityPolicy:
-
-    clc = clc_sdk
-    module = None
+class ClcAntiAffinityPolicy(module_base.ClcAnsibleModule):
 
     def __init__(self, module):
-        """
-        Construct module
-        """
-        self.module = module
-        self.policy_dict = {}
-
-        if not CLC_FOUND:
-            self.module.fail_json(
-                msg='clc-python-sdk required for this module')
-        if not REQUESTS_FOUND:
-            self.module.fail_json(
-                msg='requests library is required for this module')
-        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
-            self.module.fail_json(
-                msg='requests library  version should be >= 2.5.0')
-
-        self._set_user_agent(self.clc)
+        super(ClcAntiAffinityPolicy, self).__init__(module)
 
     @staticmethod
     def _define_module_argument_spec():
@@ -224,34 +190,6 @@ class ClcAntiAffinityPolicy:
             policy = policy.__dict__
 
         self.module.exit_json(changed=changed, policy=policy)
-
-    def _set_clc_credentials_from_env(self):
-        """
-        Set the CLC Credentials on the sdk by reading environment variables
-        :return: none
-        """
-        env = os.environ
-        v2_api_token = env.get('CLC_V2_API_TOKEN', False)
-        v2_api_username = env.get('CLC_V2_API_USERNAME', False)
-        v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
-        clc_alias = env.get('CLC_ACCT_ALIAS', False)
-        api_url = env.get('CLC_V2_API_URL', False)
-
-        if api_url:
-            self.clc.defaults.ENDPOINT_URL_V2 = api_url
-
-        if v2_api_token and clc_alias:
-            self.clc._LOGIN_TOKEN_V2 = v2_api_token
-            self.clc._V2_ENABLED = True
-            self.clc.ALIAS = clc_alias
-        elif v2_api_username and v2_api_passwd:
-            self.clc.v2.SetCredentials(
-                api_username=v2_api_username,
-                api_passwd=v2_api_passwd)
-        else:
-            return self.module.fail_json(
-                msg="You must set the CLC_V2_API_USERNAME and CLC_V2_API_PASSWD "
-                    "environment variables")
 
     def _get_policies_for_datacenter(self, p):
         """
@@ -334,16 +272,6 @@ class ClcAntiAffinityPolicy:
             if not self.module.check_mode:
                 policy = self._create_policy(p)
         return changed, policy
-
-    @staticmethod
-    def _set_user_agent(clc):
-        if hasattr(clc, 'SetRequestsSession'):
-            agent_string = "ClcAnsibleModule/" + __version__
-            ses = requests.Session()
-            ses.headers.update({"Api-Client": agent_string})
-            ses.headers['User-Agent'] += " " + agent_string
-            clc.SetRequestsSession(ses)
-
 
 def main():
     """

--- a/src/main/python/clc_ansible_module/clc_ansible_module.py
+++ b/src/main/python/clc_ansible_module/clc_ansible_module.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+# CenturyLink Cloud Ansible Modules.
+#
+# These Ansible modules enable the CenturyLink Cloud v2 API to be called
+# from an within an Ansible Playbook.
+#
+# This file is part of CenturyLink Cloud
+#
+# Copyright 2016 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CenturyLink Cloud: https://www.ctl.io/
+# API Documentation: https://www.ctl.io//api-docs/v2/
+
+
+__version__ = '${version}'
+
+from distutils.version import LooseVersion
+
+from abc import ABCMeta, abstractmethod
+
+try:
+    import requests
+except ImportError:
+    REQUESTS_FOUND = False
+else:
+    REQUESTS_FOUND = True
+
+#
+#  Requires the clc-python-sdk.
+#  sudo pip install clc-sdk
+#
+try:
+    import clc as clc_sdk
+    from clc import CLCException
+except ImportError:
+    CLC_FOUND = False
+    clc_sdk = None
+else:
+    CLC_FOUND = True
+
+
+class ClcAnsibleModule():
+    __metaclass__ = ABCMeta
+    clc = clc_sdk
+    module = None
+
+    def __init__(self, module):
+        """
+        Construct module
+        """
+        self.module = module
+        self.policy_dict = {}
+
+        if not CLC_FOUND:
+            self.module.fail_json(
+                msg='clc-python-sdk required for this module')
+        if not REQUESTS_FOUND:
+            self.module.fail_json(
+                msg='requests library is required for this module')
+        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+            self.module.fail_json(
+                msg='requests library  version should be >= 2.5.0')
+
+        self._set_user_agent(self.clc)
+
+
+    @abstractmethod
+    def _define_module_argument_spec():
+        """ This should be implemented as a static method """
+        pass
+
+    @abstractmethod
+    def process_request(self):
+        pass
+
+    def _set_clc_credentials_from_env(self):
+        """
+        Set the CLC Credentials on the sdk by reading environment variables
+        :return: none
+        """
+        env = os.environ
+        v2_api_token = env.get('CLC_V2_API_TOKEN', False)
+        v2_api_username = env.get('CLC_V2_API_USERNAME', False)
+        v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
+        clc_alias = env.get('CLC_ACCT_ALIAS', False)
+        api_url = env.get('CLC_V2_API_URL', False)
+
+        if api_url:
+            self.clc.defaults.ENDPOINT_URL_V2 = api_url
+
+        if v2_api_token and clc_alias:
+            self.clc._LOGIN_TOKEN_V2 = v2_api_token
+            self.clc._V2_ENABLED = True
+            self.clc.ALIAS = clc_alias
+        elif v2_api_username and v2_api_passwd:
+            self.clc.v2.SetCredentials(
+                api_username=v2_api_username,
+                api_passwd=v2_api_passwd)
+        else:
+            return self.module.fail_json(
+                msg="You must set the CLC_V2_API_USERNAME and CLC_V2_API_PASSWD "
+                    "environment variables")
+
+    @staticmethod
+    def _set_user_agent(clc):
+        if hasattr(clc, 'SetRequestsSession'):
+            agent_string = "ClcAnsibleModule/" + __version__
+            ses = requests.Session()
+            ses.headers.update({"Api-Client": agent_string})
+            ses.headers['User-Agent'] += " " + agent_string
+            clc.SetRequestsSession(ses)
+
+
+from ansible.module_utils.basic import *  # pylint: disable=W0614
+if __name__ == '__main__':
+    main()

--- a/src/unittest/python/test_clc_ansible_module.py
+++ b/src/unittest/python/test_clc_ansible_module.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# Copyright 2016 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import clc_ansible_module.clc_ansible_module as clc_ansible_module
+from clc_ansible_module.clc_ansible_module import ClcAnsibleModule
+import clc as clc_sdk
+from clc import CLCException
+import mock
+from mock import patch, create_autospec
+import os
+import unittest
+
+def FakeAnsibleModule():
+    module = mock.MagicMock()
+    module.check_mode = False
+    module.params = {}
+    return module
+
+class ImplementationMock(ClcAnsibleModule):
+    def __init__(self, module):
+        super(ImplementationMock, self).__init__(module)
+
+    @staticmethod
+    def _define_module_argument_spec():
+        return "_define_module_argument_spec implementation"
+
+    def process_request(self):
+        return "process_request implementation"
+
+
+class TestClcAnsibleModule(unittest.TestCase):
+
+    def setUp(self):
+        self.clc = mock.MagicMock()
+        self.module = FakeAnsibleModule()
+        self.base = ImplementationMock(self.module)
+        self.base.module.exit_json = mock.MagicMock()
+        self.base_dict = {}
+
+    def notestNoCreds(self):
+        self.base.module.fail_json = mock.MagicMock(side_effect=Exception('nocreds'))
+        try:
+            result = self.base.do_work()
+        except:
+            pass
+        self.assertEqual(self.base.module.fail_json.called, True)
+
+    @patch.object(clc_ansible_module, 'clc_sdk')
+    def test_set_user_agent(self, mock_clc_sdk):
+        clc_ansible_module.__version__ = "1"
+        ClcAnsibleModule._set_user_agent(mock_clc_sdk)
+
+        self.assertTrue(mock_clc_sdk.SetRequestsSession.called)
+
+    @patch.object(ClcAnsibleModule, 'clc')
+    def test_set_clc_credentials_from_env(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_TOKEN': 'dummyToken',
+                                       'CLC_ACCT_ALIAS': 'TEST'}):
+            self.module.fail_json.called = False
+            under_test = ImplementationMock(self.module)
+            under_test._set_clc_credentials_from_env()
+        self.assertEqual(under_test.clc._LOGIN_TOKEN_V2, 'dummyToken')
+        self.assertFalse(mock_clc_sdk.v2.SetCredentials.called)
+        self.assertEqual(self.module.fail_json.called, False)
+
+    @patch.object(ClcAnsibleModule, 'clc')
+    def test_set_clc_credentials_w_creds(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_USERNAME': 'dummyuser', 'CLC_V2_API_PASSWD': 'dummypwd'}):
+            under_test = ImplementationMock(self.module)
+            under_test._set_clc_credentials_from_env()
+            mock_clc_sdk.v2.SetCredentials.assert_called_once_with(api_username='dummyuser', api_passwd='dummypwd')
+
+    @patch.object(ClcAnsibleModule, 'clc')
+    def test_set_clc_credentials_w_api_url(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_URL': 'dummyapiurl'}):
+            under_test = ImplementationMock(self.module)
+            under_test._set_clc_credentials_from_env()
+            self.assertEqual(under_test.clc.defaults.ENDPOINT_URL_V2, 'dummyapiurl')
+
+    def test_set_clc_credentials_w_no_creds(self):
+        with patch.dict('os.environ', {}, clear=True):
+            under_test = ImplementationMock(self.module)
+            under_test._set_clc_credentials_from_env()
+        self.assertEqual(self.module.fail_json.called, True)
+
+    def test_clc_module_not_found(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'clc': raise ImportError
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_ansible_module)
+            ImplementationMock(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='clc-python-sdk required for this module')
+        reload(clc_ansible_module)
+
+    def test_requests_invalid_version(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'requests':
+                args[0]['requests'].__version__ = '2.4.0'
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_ansible_module)
+            ImplementationMock(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='requests library  version should be >= 2.5.0')
+        reload(clc_ansible_module)
+
+    def test_requests_module_not_found(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'requests':
+                args[0]['requests'].__version__ = '2.7.0'
+                raise ImportError
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_ansible_module)
+            ImplementationMock(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='requests library is required for this module')
+        reload(clc_ansible_module)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To simplify module development and cut down on copy-and-paste coding, I've extracted out the common components of all of the existing modules and created a base class.  To demonstrate how simply existing modules could be refactored, I've refactored the existing clc_aa_policy module to extend this base class.  It eliminates a few hundred lines of code between module and tests while requiring little effort to implement.  
