### PR TITLE
Clc network module

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ Create or delete Network at CenturyLink Cloud.
 | Parameter | Required | Default | Choices | Description |
 |-----------|:--------:|:-------:|:-------:|-------------|
 | `description` | N | | | Description for the network |
-| `id` | N | | | Identifier for network to be updated/deleted.  This is required when state is 'absent'.  This is used to find an existing network when state is 'present' and takes precedence over `name`. |
+| `id` | N | | | Identifier for network to be updated/deleted.  This is required when state is 'absent'.  This is used to find an existing network when state is 'present' and takes precedence over `name`.  The `id` field can be the network id, network name, or network vlan. |
 | `location` | Y | | | Datacenter in which the network lives |
 | `name` | N | | | The Name of the network.  This is used to find an existing network when state is 'present'; if not found, the claimed network is given this name. |
 | `state` | N | present | present, absent | Whether to claim or release the network |

--- a/README.md
+++ b/README.md
@@ -695,6 +695,59 @@ Create/Delete a Firewall Policy
 | `enabled` | N | True | True, False | If the firewall policy is enabled or disabled
 
 
+
+## clc_network Module
+
+Create or delete Network at CenturyLink Cloud.
+
+###Example Playbook
+```yaml
+---
+- name: Create Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Create and update a new network
+      clc_network:
+        location: 'ut1'
+        state: present
+        name: 'ProdNet5000'
+        description: 'Production Minecraft'
+      register: net
+
+    - debug: var=net
+```
+```
+---
+- name: Delete Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Delete-ification
+      clc_network:
+        location: 'ut1'
+        state: absent
+        id: 'vlan_1306_10.81.206'
+      register: net
+
+    - debug: var=net
+
+```
+
+###Available Parameters
+
+| Parameter | Required | Default | Choices | Description |
+|-----------|:--------:|:-------:|:-------:|-------------|
+| `description` | N | | | Description for the network |
+| `id` | N | | | Identifier for network to be updated/deleted.  This is required when state is 'absent'.  This is used to find an existing network when state is 'present' and takes precedence over `name`. |
+| `location` | Y | | | Datacenter in which the network lives |
+| `name` | N | | | The Name of the network.  This is used to find an existing network when state is 'present'; if not found, the claimed network is given this name. |
+| `state` | N | present | present, absent | Whether to claim or release the network |
+| `wait` | N | True | True, False | Whether to wait for network create to complete |
+
+
 ## <a id="dyn_inventory"></a>Dynamic Inventory Script
 
 Scans all datacenters and returns an inventory of servers and server groups to Ansible.  This script returns all information about hosts in the inventory _meta dictionary.

--- a/example-playbooks/example_clc_network_create_playbook.yml
+++ b/example-playbooks/example_clc_network_create_playbook.yml
@@ -1,0 +1,14 @@
+- name: Create Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Create and update a new network
+      clc_network:
+        location: 'ut1'
+        state: present
+        name: 'ProdNet5000'
+        description: 'Production Minecraft'
+      register: net
+
+    - debug: var=net

--- a/example-playbooks/example_clc_network_delete_playbook.yml
+++ b/example-playbooks/example_clc_network_delete_playbook.yml
@@ -1,0 +1,13 @@
+- name: Delete Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Delete-ification
+      clc_network:
+        location: 'ut1'
+        state: absent
+        id: 'vlan_1306_10.81.206'
+      register: net
+
+    - debug: var=net

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -257,9 +257,15 @@ class ClcNetwork:
 
       return changed
 
+    def _get_search_key(self, params):
+      if params.get('id', None) is not None:
+        return params.get('id', None)
+
+      return params.get('name', None)
+
     def _ensure_network_present(self, params):
       changed = False
-      search_key = params.get('id') if 'id' in params else params.get('name', None)
+      search_key = self._get_search_key(params)
       network = self.networks.Get(search_key)
 
       if network is None:

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -223,8 +223,13 @@ class ClcNetwork:
         else:
           changed, network = self._ensure_network_present(p)
 
-        if network:
+        if hasattr(network, 'data'):
           network = network.data
+        elif hasattr(network, 'requests'):
+          network = {
+            "id": network.requests[0].id,
+            "uri": network.requests[0].uri
+          }
 
         self.module.exit_json(changed=changed, network=network)
 

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -31,21 +31,25 @@ description:
   - An Ansible module to Create or Delete networks at CenturyLink Cloud.
 version_added: "2.0"
 options:
-  name:
-    description:
-      - The name of the network.
-    required: True
-  location:
-    description:
-      - Datacenter in which the network lives/should live.
-    required: True
   description:
     description:
       - A free text field for describing the network's purpose
     required: False
+  id:
+    description:
+      - The id for the network being updated or deleted; required when state = 'absent'.
+    required: False
+  location:
+    description:
+      - Datacenter in which the network lives/should live.
+    required: True
+  name:
+    description:
+      - The name of the network.  Used to find an existing network when state='present'.
+    required: False
   state:
     description:
-      - Whether to create or delete the network.
+      - Whether to claim or release the network.
     required: False
     default: present
     choices: ['present','absent']
@@ -80,15 +84,15 @@ EXAMPLES = '''
   gather_facts: False
   connection: local
   tasks:
-    - name: Create a network
+    - name: Create and update a new network
       clc_network:
-        name: 'Storage Network'
-        location: 'UK3'
+        location: 'ut1'
         state: present
-      register: network
+        name: 'ProdNet5000'
+        description: 'Production Minecraft'
+      register: net
 
-    - name: debug
-      debug: var=network
+    - debug: var=nettwork
 
 ---
 - name: Delete Network
@@ -96,15 +100,14 @@ EXAMPLES = '''
   gather_facts: False
   connection: local
   tasks:
-    - name: Delete an network
+    - name: Delete-ification
       clc_network:
-        name: 'Storage Network'
-        location: 'UK3'
+        location: 'ut1'
         state: absent
-      register: network
+        id: 'vlan_1306_10.81.206'
+      register: net
 
-    - name: debug
-      debug: var=network
+    - debug: var=net
 '''
 
 RETURN = '''

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -213,7 +213,17 @@ class ClcNetwork:
 
         self._set_clc_credentials_from_env()
 
+        self._populate_networks(p.get('location'))
+
+        self._ensure_network_present(
+          location=p.get('location'),
+          wait=p.get('wait', True)
+        )
+
         self.module.exit_json()
+
+    def _populate_networks(self, location):
+      self.networks = self.clc.v2.Networks(location=location)
 
     @staticmethod
     def _set_user_agent(clc):
@@ -224,6 +234,11 @@ class ClcNetwork:
             ses.headers['User-Agent'] += " " + agent_string
             clc.SetRequestsSession(ses)
 
+    def _ensure_network_present(self, location, wait=True):
+      request = self.clc.v2.Network.Create(location=location)
+
+      if wait:
+        request.WaitUntilComplete()
 
 def main():
     """

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -300,7 +300,7 @@ class ClcNetwork:
       name = params.get('name', None)
       desc = params.get('description', None)
 
-      if (name is not None and network.name != name) or (desc is not None and network.description != name):
+      if (name is not None and network.name != name) or (desc is not None and network.description != desc):
         changed = True
         update_name = name if name is not None else network.name
         if desc is not None:

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -210,19 +210,22 @@ class ClcNetwork:
         :return: Returns with either an exit_json or fail_json
         """
         changed = False
-        return_val = None
+        network = None
         p = self.module.params
 
         self._set_clc_credentials_from_env()
 
         self.networks = self._populate_networks(p.get('location'))
 
-        changed, network = self._ensure_network_present(p)
+        if p.get('state') == 'absent':
+          changed = self._ensure_network_absent(p)
+        else:
+          changed, network = self._ensure_network_present(p)
 
         if network:
-          return_val = network.data
+          network = network.data
 
-        self.module.exit_json(changed=changed, network=return_val)
+        self.module.exit_json(changed=changed, network=network)
 
     def _populate_networks(self, location):
       return self.clc.v2.Networks(location=location)

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -301,6 +301,7 @@ class ClcNetwork:
       desc = params.get('description', None)
 
       if (name is not None and network.name != name) or (desc is not None and network.description != name):
+        changed = True
         update_name = name if name is not None else network.name
         if desc is not None:
           network.Update(update_name, description=desc, location=location)

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -322,7 +322,7 @@ def main():
     """
     module = AnsibleModule(
         argument_spec=ClcNetwork._define_module_argument_spec(),
-        supports_check_mode=True)
+        supports_check_mode=False)
     clc_network = ClcNetwork(module)
     clc_network.process_request()
 

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -298,7 +298,7 @@ class ClcNetwork:
       changed = False
       location = params.get('location')
       name = params.get('name', None)
-      desc = params.get('desc', None)
+      desc = params.get('description', None)
 
       if (name is not None and network.name != name) or (desc is not None and network.description != name):
         update_name = name if name is not None else network.name

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -171,7 +171,7 @@ class ClcNetwork:
             name=dict(required=False),
             location=dict(required=True),
             description=dict(required=False),
-            wait=dict(default=True),
+            wait=dict(default=True, type='bool'),
             state=dict(default='present', choices=['present', 'absent']),
         )
         return argument_spec

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -248,7 +248,8 @@ class ClcNetwork:
         network = request
 
         if params.get('wait') if 'wait' in params else True:
-          request.WaitUntilComplete()
+          if request.WaitUntilComplete() > 0:
+            self.module.fail_json(msg="Unable to create network")
           network = self.clc.v2.Networks(location=location).Get(key=name)
 
       return changed, network

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -276,10 +276,11 @@ class ClcNetwork:
       request = self.clc.v2.Network.Create(location=params.get('location'))
 
       if params.get('wait',True):
+        uri = request.requests[0].uri
         if request.WaitUntilComplete() > 0:
           self.module.fail_json(msg="Unable to create network")
-        network_payload = self.clc.v2.API.Call(
-          self.clc.v2.API.Call(request.uri)['summary']['links'][0]['href'])
+        network_payload = self.clc.v2.API.Call('GET',
+          self.clc.v2.API.Call('GET', uri)['summary']['links'][0]['href'])
         request = self.clc.v2.Network(network_payload['id'], network_obj=network_payload)
 
         if name is not None or desc is not None:

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+
+# CenturyLink Cloud Ansible Modules.
+#
+# These Ansible modules enable the CenturyLink Cloud v2 API to be called
+# from an within Ansible Playbook.
+#
+# This file is part of CenturyLink Cloud
+#
+# Copyright 2016 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CenturyLink Cloud: http://www.ctl.op
+# API Documentation: https://www.ctl.io/api-docs/v2/
+
+DOCUMENTATION = '''
+module: clc_network
+short_description: Create or Delete networks at CenturyLink Cloud.
+description:
+  - An Ansible module to Create or Delete networks at CenturyLink Cloud.
+version_added: "2.0"
+options:
+  name:
+    description:
+      - The name of the network.
+    required: True
+  location:
+    description:
+      - Datacenter in which the network lives/should live.
+    required: True
+  description:
+    description:
+      - A free text field for describing the network's purpose
+    required: False
+  state:
+    description:
+      - Whether to create or delete the network.
+    required: False
+    default: present
+    choices: ['present','absent']
+  wait:
+    description:
+      - Whether to wait for the tasks to finish before returning.
+    default: True
+    required: False
+    choices: [True, False]
+requirements:
+    - python = 2.7
+    - requests >= 2.5.0
+    - clc-sdk
+notes:
+    - To use this module, it is required to set the below environment variables which enables access to the
+      Centurylink Cloud
+          - CLC_V2_API_USERNAME, the account login id for the centurylink cloud
+          - CLC_V2_API_PASSWORD, the account password for the centurylink cloud
+    - Alternatively, the module accepts the API token and account alias. The API token can be generated using the
+      CLC account login and password via the HTTP api call @ https://api.ctl.io/v2/authentication/login
+          - CLC_V2_API_TOKEN, the API token generated from https://api.ctl.io/v2/authentication/login
+          - CLC_ACCT_ALIAS, the account alias associated with the centurylink cloud
+    - Users can set CLC_V2_API_URL to specify an endpoint for pointing to a different CLC environment.
+'''
+
+EXAMPLES = '''
+# Note - You must set the CLC_V2_API_USERNAME And CLC_V2_API_PASSWD Environment variables before running these examples
+
+---
+- name: Create Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Create a network
+      clc_network:
+        name: 'Storage Network'
+        location: 'UK3'
+        state: present
+      register: network
+
+    - name: debug
+      debug: var=network
+
+---
+- name: Delete Network
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  tasks:
+    - name: Delete an network
+      clc_network:
+        name: 'Storage Network'
+        location: 'UK3'
+        state: absent
+      register: network
+
+    - name: debug
+      debug: var=network
+'''
+
+RETURN = '''
+TBD
+'''
+
+__version__ = '${version}'
+
+from distutils.version import LooseVersion
+
+try:
+    import requests
+except ImportError:
+    REQUESTS_FOUND = False
+else:
+    REQUESTS_FOUND = True
+
+#
+#  Requires the clc-python-sdk.
+#  sudo pip install clc-sdk
+#
+try:
+    import clc as clc_sdk
+    from clc import CLCException
+except ImportError:
+    CLC_FOUND = False
+    clc_sdk = None
+else:
+    CLC_FOUND = True
+
+
+class ClcNetwork:
+
+    clc = clc_sdk
+    module = None
+
+    def __init__(self, module):
+        """
+        Construct module
+        """
+        self.module = module
+        self.network_dict = {}
+
+        if not CLC_FOUND:
+            self.module.fail_json(
+                msg='clc-python-sdk required for this module')
+        if not REQUESTS_FOUND:
+            self.module.fail_json(
+                msg='requests library is required for this module')
+        if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
+            self.module.fail_json(
+                msg='requests library  version should be >= 2.5.0')
+
+        self._set_user_agent(self.clc)
+
+    @staticmethod
+    def _define_module_argument_spec():
+        """
+        Define the argument spec for the ansible module
+        :return: argument spec dictionary
+        """
+        argument_spec = dict(
+            name=dict(required=True),
+            location=dict(required=True),
+            description=dict(required=False),
+            wait=dict(default=True),
+            state=dict(default='present', choices=['present', 'absent']),
+        )
+        return argument_spec
+
+    def _set_clc_credentials_from_env(self):
+        """
+        Set the CLC Credentials on the sdk by reading environment variables
+        :return: none
+        """
+        env = os.environ
+        v2_api_token = env.get('CLC_V2_API_TOKEN', False)
+        v2_api_username = env.get('CLC_V2_API_USERNAME', False)
+        v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
+        clc_alias = env.get('CLC_ACCT_ALIAS', False)
+        api_url = env.get('CLC_V2_API_URL', False)
+
+        if api_url:
+            self.clc.defaults.ENDPOINT_URL_V2 = api_url
+
+        if v2_api_token and clc_alias:
+            self.clc._LOGIN_TOKEN_V2 = v2_api_token
+            self.clc._V2_ENABLED = True
+            self.clc.ALIAS = clc_alias
+        elif v2_api_username and v2_api_passwd:
+            self.clc.v2.SetCredentials(
+                api_username=v2_api_username,
+                api_passwd=v2_api_passwd)
+        else:
+            return self.module.fail_json(
+                msg="You must set the CLC_V2_API_USERNAME and CLC_V2_API_PASSWD "
+                    "environment variables")
+
+    # Module Behavior Goodness
+    def process_request(self):
+        """
+        Process the request - Main Code Path
+        :return: Returns with either an exit_json or fail_json
+        """
+        p = self.module.params
+
+        self._set_clc_credentials_from_env()
+
+        self.module.exit_json()
+
+    @staticmethod
+    def _set_user_agent(clc):
+        if hasattr(clc, 'SetRequestsSession'):
+            agent_string = "ClcAnsibleModule/" + __version__
+            ses = requests.Session()
+            ses.headers.update({"Api-Client": agent_string})
+            ses.headers['User-Agent'] += " " + agent_string
+            clc.SetRequestsSession(ses)
+
+
+def main():
+    """
+    The main function.  Instantiates the module and calls process_request.
+    :return: none
+    """
+    module = AnsibleModule(
+        argument_spec=ClcNetwork._define_module_argument_spec(),
+        supports_check_mode=True)
+    clc_network = ClcNetwork(module)
+    clc_network.process_request()
+
+from ansible.module_utils.basic import *  # pylint: disable=W0614
+if __name__ == '__main__':
+    main()

--- a/src/main/python/clc_ansible_module/clc_network.py
+++ b/src/main/python/clc_ansible_module/clc_network.py
@@ -38,6 +38,7 @@ options:
   id:
     description:
       - The id for the network being updated or deleted; required when state = 'absent'.
+        This can be the network's id, name, or vlan -- as these can all be used to uniquely id the network.
     required: False
   location:
     description:

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -31,7 +31,6 @@ def FakeAnsibleModule():
 class TestClcNetwork(unittest.TestCase):
 
     def setUp(self):
-        self.clc = mock.MagicMock()
         self.module = FakeAnsibleModule()
         self.network = ClcNetwork(self.module)
         self.network.module.exit_json = mock.MagicMock()
@@ -153,7 +152,7 @@ class TestClcNetwork(unittest.TestCase):
     # End copy/pasta tests
 
 
-    def testArgumentSpecContract(self):
+    def test_argument_spec_contract(self):
         args = ClcNetwork._define_module_argument_spec()
         self.assertEqual(args, dict(
             name=dict(required=True),
@@ -162,6 +161,62 @@ class TestClcNetwork(unittest.TestCase):
             state=dict(default='present', choices=['present', 'absent']),
             wait=dict(default=True)
         ))
+
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_populates_network_list(self, mock_set_creds):
+        mock_nets = mock.MagicMock()
+        self.network.clc.v2.Networks = mock.MagicMock(return_value=mock_nets)
+        self.module.params = {
+            'location': 'mock_loc'
+        }
+
+        self.network.process_request()
+
+        self.network.clc.v2.Networks.assert_called_once_with(location="mock_loc")
+        self.assertEqual(mock_nets, self.network.networks)
+
+    @patch.object(ClcNetwork, '_populate_networks')
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_for_create_calls_sdk_network_create(self, mock_set_creds, mock_nets):
+        self.network.clc.v2.Network.Create = mock.MagicMock()
+        self.module.params = {
+            'location': 'mock_loc'
+        }
+
+        self.network.process_request()
+
+        self.network.clc.v2.Network.Create.assert_called_once_with(location="mock_loc")
+        self.assertEqual(self.module.fail_json.called, False)
+
+    @patch.object(ClcNetwork, '_populate_networks')
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_for_create_waits_on_request(self, mock_set_creds, mock_nets):
+        mock_request = mock.MagicMock()
+        mock_request.WaitUntilComplete = mock.MagicMock(return_value=0)
+        self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_request)
+        self.module.params = {
+            'location': 'mock_loc'
+        }
+
+        self.network.process_request()
+
+        self.assertEqual(1, mock_request.WaitUntilComplete.call_count)
+
+    @patch.object(ClcNetwork, '_populate_networks')
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_for_create_skips_wait_when_wait_false(self, mock_set_creds, mock_nets):
+        mock_request = mock.MagicMock()
+        mock_request.WaitUntilComplete = mock.MagicMock(return_value=0)
+        self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_request)
+        self.module.params = {
+            'location': 'mock_loc',
+            'wait': False
+        }
+
+        self.network.process_request()
+
+        self.assertEqual(0, mock_request.WaitUntilComplete.call_count)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -364,7 +364,7 @@ class TestClcNetwork(unittest.TestCase):
             self.module.params = {
                 'id': 'existing',
                 'name': name,
-                'desc': desc,
+                'description': desc,
                 'location': 'mock_loc',
             }
 

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -417,6 +417,33 @@ class TestClcNetwork(unittest.TestCase):
 
             self.module.exit_json.assert_called_once_with(changed=True,network=mock_new.data)
 
+
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_present_exits_with_expected_request_when_wait_false(self, mock_set_creds):
+        with patch.object(ClcNetwork, '_populate_networks', return_value=self.mock_nets):
+            op_id = "operationId"
+            op_uri = "/v2-experimental/operations/xxx/status/operationId"
+            mock_request = mock.MagicMock()
+            mock_request.id = op_id
+            mock_request.uri = op_uri
+            mock_requests = create_autospec(clc_sdk.v2.Requests)
+            mock_requests.requests = [mock_request]
+            self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_requests)
+            self.module.params = {
+                'location': 'mock_loc',
+                'wait': False
+            }
+
+            self.network.process_request()
+
+            expected = {
+                "id": op_id,
+                "uri": op_uri
+            }
+
+            self.module.exit_json.assert_called_once_with(changed=True,network=expected)
+
+
     @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
     def test_process_request_for_delete_calls_sdk_delete_and_reports_change(self, mock_set_creds):
         with patch.object(ClcNetwork, '_populate_networks', return_value=self.mock_nets) as mock_nets:

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# Copyright 2016 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import clc_ansible_module.clc_network as clc_network
+from clc_ansible_module.clc_network import ClcNetwork
+import clc as clc_sdk
+from clc import CLCException
+import mock
+from mock import patch, create_autospec
+import os
+import unittest
+
+def FakeAnsibleModule():
+    module = mock.MagicMock()
+    module.check_mode = False
+    module.params = {}
+    return module
+
+class TestClcNetwork(unittest.TestCase):
+
+    def setUp(self):
+        self.clc = mock.MagicMock()
+        self.module = FakeAnsibleModule()
+        self.network = ClcNetwork(self.module)
+        self.network.module.exit_json = mock.MagicMock()
+        self.network_dict = {}
+
+    # Begin copy/pasta tests
+
+    def test_api_set_credentials(self):
+        self.network.clc.v2.SetCredentials = mock.MagicMock()
+        with patch.dict('os.environ', {'CLC_V2_API_USERNAME':'passWORD', 'CLC_V2_API_PASSWD':'UsErnaME'}):
+            try:
+                self.network.process_request()
+            except:
+                # It'll die, and we don't care
+                pass
+
+        self.network.clc.v2.SetCredentials.assert_called_once_with(api_username='passWORD',api_passwd='UsErnaME')
+
+    @patch.object(clc_network, 'clc_sdk')
+    def test_set_user_agent(self, mock_clc_sdk):
+        clc_network.__version__ = "1"
+        ClcNetwork._set_user_agent(mock_clc_sdk)
+
+        self.assertTrue(mock_clc_sdk.SetRequestsSession.called)
+
+    @patch.object(ClcNetwork, 'clc')
+    def test_set_clc_credentials_from_env(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_TOKEN': 'dummyToken',
+                                       'CLC_ACCT_ALIAS': 'TEST'}):
+            self.module.fail_json.called = False
+            under_test = ClcNetwork(self.module)
+            under_test._set_clc_credentials_from_env()
+        self.assertEqual(under_test.clc._LOGIN_TOKEN_V2, 'dummyToken')
+        self.assertFalse(mock_clc_sdk.v2.SetCredentials.called)
+        self.assertEqual(self.module.fail_json.called, False)
+
+    @patch.object(ClcNetwork, 'clc')
+    def test_set_clc_credentials_w_creds(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_USERNAME': 'dummyuser', 'CLC_V2_API_PASSWD': 'dummypwd'}):
+            under_test = ClcNetwork(self.module)
+            under_test._set_clc_credentials_from_env()
+            mock_clc_sdk.v2.SetCredentials.assert_called_once_with(api_username='dummyuser', api_passwd='dummypwd')
+
+    @patch.object(ClcNetwork, 'clc')
+    def test_set_clc_credentials_w_api_url(self, mock_clc_sdk):
+        with patch.dict('os.environ', {'CLC_V2_API_URL': 'dummyapiurl'}):
+            under_test = ClcNetwork(self.module)
+            under_test._set_clc_credentials_from_env()
+            self.assertEqual(under_test.clc.defaults.ENDPOINT_URL_V2, 'dummyapiurl')
+
+    def test_set_clc_credentials_w_no_creds(self):
+        with patch.dict('os.environ', {}, clear=True):
+            under_test = ClcNetwork(self.module)
+            under_test._set_clc_credentials_from_env()
+        self.assertEqual(self.module.fail_json.called, True)
+
+    def test_clc_module_not_found(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'clc': raise ImportError
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_network)
+            clc_network.ClcNetwork(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='clc-python-sdk required for this module')
+        reload(clc_network)
+
+    def test_requests_invalid_version(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'requests':
+                args[0]['requests'].__version__ = '2.4.0'
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_network)
+            clc_network.ClcNetwork(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='requests library  version should be >= 2.5.0')
+        reload(clc_network)
+
+    def test_requests_module_not_found(self):
+        # Setup Mock Import Function
+        import __builtin__ as builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args):
+            if name == 'requests':
+                args[0]['requests'].__version__ = '2.7.0'
+                raise ImportError
+            return real_import(name, *args)
+        # Under Test
+        with mock.patch('__builtin__.__import__', side_effect=mock_import):
+            reload(clc_network)
+            clc_network.ClcNetwork(self.module)
+        # Assert Expected Behavior
+        self.module.fail_json.assert_called_with(msg='requests library is required for this module')
+        reload(clc_network)
+
+    @patch.object(clc_network, 'AnsibleModule')
+    @patch.object(clc_network, 'ClcNetwork')
+    def test_main(self, mock_ClcNetwork, mock_AnsibleModule):
+        mock_ClcNetwork_instance        = mock.MagicMock()
+        mock_AnsibleModule_instance     = mock.MagicMock()
+        mock_ClcNetwork.return_value    = mock_ClcNetwork_instance
+        mock_AnsibleModule.return_value = mock_AnsibleModule_instance
+
+        clc_network.main()
+
+        mock_ClcNetwork.assert_called_once_with(mock_AnsibleModule_instance)
+        assert mock_ClcNetwork_instance.process_request.call_count ==1
+
+
+    # End copy/pasta tests
+
+
+    def testArgumentSpecContract(self):
+        args = ClcNetwork._define_module_argument_spec()
+        self.assertEqual(args, dict(
+            name=dict(required=True),
+            location=dict(required=True),
+            description=dict(required=False),
+            state=dict(default='present', choices=['present', 'absent']),
+            wait=dict(default=True)
+        ))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -264,7 +264,7 @@ class TestClcNetwork(unittest.TestCase):
             network_uri: new_network
         }
 
-        self.network.clc.v2.API.Call = mock.MagicMock(side_effect=lambda uri: response_map[uri] if uri in response_map else 'doing it wrong')
+        self.network.clc.v2.API.Call = mock.MagicMock(side_effect=lambda x, uri: response_map[uri] if uri in response_map else 'doing it wrong')
 
         # Step the Third: Mock the instantiation of a v2 Network object
         mock_network = mock.MagicMock()
@@ -277,7 +277,7 @@ class TestClcNetwork(unittest.TestCase):
         mock_requests = mock.MagicMock()
         mock_requests.requests = [mock_request]
         mock_requests.WaitUntilComplete = mock.MagicMock(return_value=0)
-        self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_request)
+        self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_requests)
         mock_update.return_value = True, mock_network
 
         return status_uri, network_uri, mock_network
@@ -298,8 +298,8 @@ class TestClcNetwork(unittest.TestCase):
             self.network.process_request()
 
             self.assertEqual(2, self.network.clc.v2.API.Call.call_count)
-            self.network.clc.v2.API.Call.assert_any_call(uri1)
-            self.network.clc.v2.API.Call.assert_called_with(uri2)
+            self.network.clc.v2.API.Call.assert_any_call('GET', uri1)
+            self.network.clc.v2.API.Call.assert_called_with('GET', uri2)
             self.network.clc.v2.Network.assert_called_once_with(network_id,network_obj=mock_network.data)
             mock_update.assert_called_once_with(mock_network,self.module.params)
 
@@ -317,8 +317,8 @@ class TestClcNetwork(unittest.TestCase):
             self.network.process_request()
 
             self.assertEqual(2, self.network.clc.v2.API.Call.call_count)
-            self.network.clc.v2.API.Call.assert_any_call(uri1)
-            self.network.clc.v2.API.Call.assert_called_with(uri2)
+            self.network.clc.v2.API.Call.assert_any_call('GET', uri1)
+            self.network.clc.v2.API.Call.assert_called_with('GET', uri2)
             self.network.clc.v2.Network.assert_called_once_with(network_id,network_obj=mock_network.data)
             mock_update.assert_not_called()
 

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -170,7 +170,7 @@ class TestClcNetwork(unittest.TestCase):
             location=dict(required=True),
             description=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
-            wait=dict(default=True)
+            wait=dict(default=True, type='bool')
         ))
 
     @patch.object(ClcNetwork, '_set_clc_credentials_from_env')

--- a/src/unittest/python/test_clc_network.py
+++ b/src/unittest/python/test_clc_network.py
@@ -195,7 +195,6 @@ class TestClcNetwork(unittest.TestCase):
             self.network.process_request()
 
             self.network.clc.v2.Network.Create.assert_called_once_with(location="mock_loc")
-            self.assertEqual(self.module.fail_json.called, False)
 
     @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
     def test_process_request_for_create_waits_on_request(self, mock_set_creds):
@@ -211,6 +210,23 @@ class TestClcNetwork(unittest.TestCase):
             self.network.process_request()
 
             self.assertEqual(1, mock_request.WaitUntilComplete.call_count)
+            self.assertEqual(self.module.fail_json.called, False)
+
+    @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
+    def test_process_request_for_create_waits_on_request(self, mock_set_creds):
+        with patch.object(ClcNetwork, '_populate_networks', return_value=self.mock_nets) as mock_nets:
+            mock_request = mock.MagicMock()
+            mock_request.WaitUntilComplete = mock.MagicMock(return_value=1)
+            self.network.clc.v2.Network.Create = mock.MagicMock(return_value=mock_request)
+            self.module.params = {
+                'name': 'nope',
+                'location': 'mock_loc'
+            }
+
+            self.network.process_request()
+
+            self.assertEqual(1, mock_request.WaitUntilComplete.call_count)
+            self.module.fail_json.assert_called_once_with(msg="Unable to create network")
 
     @patch.object(ClcNetwork, '_set_clc_credentials_from_env')
     def test_process_request_for_create_skips_wait_when_wait_false(self, mock_set_creds):


### PR DESCRIPTION
New module for creating (claiming), deleting (releasing), and updating CLC networks.  Contingent on enhancements to the clc-python-sdk covered by https://github.com/CenturyLinkCloud/clc-python-sdk/pull/32.  

Some notes:
- All network functions in the v2 API are considered experimental, so shenanigans ensue.
- The `wait` parameter is only valid for claim requests (`state = present`).  The v2-experimental API does not offer the ability to asynchronously release networks.  Network updates are instantaneous, so there is not a concern there.
- API functionality (both v2 and python SDK) around experimental blueprints is considerably less fleshed out than for non-experimental blueprints.  I.e. there is far more code invoking v2 API calls than should be needed and should be a candidate for refactoring if and when network is promoted from 'experimental' to 'real boy'.
- The `id` field used for updates and releases is overloaded and can take a network id, name, or vlan (similarly to how it can be used in the clc_server module).  
