### PR TITLE
Restructure publicip

### DIFF
--- a/example-playbooks/example_clc_publicip_delete_playbook.yml
+++ b/example-playbooks/example_clc_publicip_delete_playbook.yml
@@ -1,11 +1,11 @@
 # Copyright 2015 CenturyLink
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@
   tasks:
     - name: Delete All Public IPs For Servers
       clc_publicip:
-        server_ids:
-            - UC1NJSTTRAIN58
-            - UC1NJSTTRAIN59
+        server_id: UC1NJSTTRAIN58
         state: absent
       register: clc

--- a/example-playbooks/example_clc_publicip_playbook.yml
+++ b/example-playbooks/example_clc_publicip_playbook.yml
@@ -1,11 +1,11 @@
 # Copyright 2015 CenturyLink
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,12 +19,11 @@
   tasks:
     - name: Create Public IP For Servers
       clc_publicip:
-        protocol: 'TCP'
         ports:
-            - 80
-        server_ids:
-            - UC1WFADTEST01
-            - UC1WFADTEST02
+          - {protocol: 'UDP', port: 23456}
+          - {protocol: 'TCP', port: 10000, port_to: 10050}
+          - {port: 80}
+        server_id: UC1WFADTEST01
         source_restrictions:
             - 70.100.60.140/32
             - 71.100.60.0/24

--- a/src/main/python/clc_ansible_module/clc_publicip.py
+++ b/src/main/python/clc_ansible_module/clc_publicip.py
@@ -232,7 +232,7 @@ class ClcPublicIp(object):
                   results: The result list from clc public ip call
         """
         changed = False
-        results = []
+        result  = ""
         changed_server_id = ""
         restrictions_list = []
         server = self._get_server_from_clc(
@@ -246,10 +246,9 @@ class ClcPublicIp(object):
 
         if not self.module.check_mode:
             result = self._add_publicip_to_server(server, ports_to_expose, source_restrictions=restrictions_list)
-            results.append(result)
         changed_server_id = server.id
         changed = True
-        return changed, changed_server_id, results
+        return changed, changed_server_id, result
 
     def _add_publicip_to_server(self, server, ports_to_expose, source_restrictions=None):
         result = None
@@ -271,17 +270,16 @@ class ClcPublicIp(object):
                   results: The result list from clc public ip call
         """
         changed = False
-        results = []
+        result  = ""
         changed_server_id = ""
         server  = self._get_server_from_clc(
             server_id,
             'Failed to obtain server from the CLC API')
         if not self.module.check_mode:
             result = self._remove_publicip_from_server(server)
-            results.append(result)
         changed_server_id = server.id
         changed = True
-        return changed, changed_server_id, results
+        return changed, changed_server_id, result
 
     def _remove_publicip_from_server(self, server):
         result = None

--- a/src/main/python/clc_ansible_module/clc_publicip.py
+++ b/src/main/python/clc_ansible_module/clc_publicip.py
@@ -42,7 +42,9 @@ options:
     required: False
   ports:
     description:
-      - A list of structures specifying port and protocol ('TCP','UDP')
+      - A list of structures specifying port (required), protocol ['TCP','UDP'] (required), and
+        port_to (optional)
+      - Example: {protocol: 'TCP', port: 10000, port_to: 10050}
     required: False
     default: None
   server_id:
@@ -96,8 +98,9 @@ EXAMPLES = '''
     - name: Create Public IP For Servers
       clc_publicip:
         ports:
-            - {'port': 80}
-            - {'port': 24601, 'protocol': 'UDP'}
+            - {port: 80, protocol: 'TCP'}
+            - {port: 10000, port_to: 10050}
+            - {port: 24601, protocol: 'UDP'}
         server_id: UC1TEST-SVR01
         state: present
       register: clc
@@ -213,7 +216,9 @@ class ClcPublicIp(object):
     def _validate_ports(self, ports):
         """
         Validates the provided list of port structures
-        :param ports: list of dictionaries specifying port and protocol
+        Note that this is required because Ansible does not seem to validate argument specs
+        beyond the first level of the dictionary
+        :param ports: list of dictionaries specifying port, protocol, and an optional port_to
         :return: list of validated ports
         """
         validated_ports = []
@@ -248,7 +253,8 @@ class ClcPublicIp(object):
                 type='list',
                 default=[],
                 protocol=dict(default='TCP', choices=['TCP', 'UDP']),
-                port=dict(required=True)
+                port=dict(required=True),
+                port_to=dict()
             ),
             source_restrictions=dict(type='list'),
             wait=dict(type='bool', default=True),

--- a/src/main/python/clc_ansible_module/clc_publicip.py
+++ b/src/main/python/clc_ansible_module/clc_publicip.py
@@ -8,7 +8,7 @@
 # This file is part of CenturyLink Cloud, and is maintained
 # by the Workflow as a Service Team
 #
-# Copyright 2015 CenturyLink 
+# Copyright 2015 CenturyLink
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ EXAMPLES = '''
   gather_facts: False
   connection: local
   tasks:
-    - name: Create Public IP For Servers
+    - name: Delete Public IP For Servers
       clc_publicip:
         server_ids:
             - UC1TEST-SVR01

--- a/src/main/python/clc_ansible_module/clc_publicip.py
+++ b/src/main/python/clc_ansible_module/clc_publicip.py
@@ -293,6 +293,11 @@ class ClcPublicIp(object):
 
     def _add_publicip_to_server(self, server, ports_to_expose, private_ip=None, source_restrictions=None):
         result = None
+
+        # We are mimicing Control here and auto-enabling ping
+        # Port is set to 0 because all 'ports' must have a port
+        ports_to_expose.insert(0, {'protocol': 'ICMP', 'port': 0})
+
         try:
             result = server.PublicIPs().Add(
                 ports=ports_to_expose

--- a/src/main/python/clc_ansible_module/clc_publicip.py
+++ b/src/main/python/clc_ansible_module/clc_publicip.py
@@ -43,7 +43,7 @@ options:
   ports:
     description:
       - A list of structures specifying port (required), protocol ['TCP','UDP'] (required), and
-        port_to (optional)
+        port_to (optional; used when specifying a range of ports)
       - Example: {protocol: 'TCP', port: 10000, port_to: 10050}
     required: False
     default: None
@@ -266,7 +266,7 @@ class ClcPublicIp(object):
         """
         Ensures the given server ids having the public ip available
         :param server_id: the server id
-        :param private_ip: optional private ip to which private ip should be NAT'ed
+        :param private_ip: optional private ip to which public ip should be NAT'ed
         :param ports: list of dictionaries specifying ports and protocols to expose
         :param source_restrictions: The list of IP range allowed to access the public IP, specified using CIDR notation.
         :return: (changed, changed_server_id, result)

--- a/src/unittest/python/test_clc_publicip.py
+++ b/src/unittest/python/test_clc_publicip.py
@@ -216,7 +216,7 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         mock_server.data = {'details': {'ipAddresses': [{'internal': '1.2.3.4'}]}}
         mock_server.PublicIPs().Add.side_effect = error
         under_test = ClcPublicIp(self.module)
-        under_test._add_publicip_to_server(mock_server, 'ports')
+        under_test._add_publicip_to_server(mock_server, ['ports'])
         self.module.fail_json.assert_called_once_with(
             msg='Failed to add public ip to the server : TESTSVR1. Mock failure message')
 
@@ -476,6 +476,8 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         mock_server = mock.MagicMock()
         private_ip = '2.4.6.0.1'
         ports = [{'protocol': 'UDP', 'port': 8675309}]
+        ports_with_icmp = [{'protocol': 'UDP', 'port': 8675309}]
+        ports_with_icmp.insert(0, {'protocol': 'ICMP', 'port': 0})
         restrictions = [{'cidr': 'cider'}]
         under_test = ClcPublicIp(self.module)
         under_test._add_publicip_to_server( server=mock_server,
@@ -483,7 +485,7 @@ class TestClcPublicIpFunctions(unittest.TestCase):
                                             ports_to_expose=ports,
                                             source_restrictions=restrictions)
         mock_server.PublicIPs().Add.assert_called_once_with(
-            ports=ports
+            ports=ports_with_icmp
             , private_ip=private_ip
             , source_restrictions=restrictions
         )

--- a/src/unittest/python/test_clc_publicip.py
+++ b/src/unittest/python/test_clc_publicip.py
@@ -33,18 +33,16 @@ class TestClcPublicIpFunctions(unittest.TestCase):
 
 
     #TODO: Put this in a Util/test_data class
-    def build_mock_server_list(self):
+    def build_mock_server(self):
         # Mock Add IP Requests
         mock_req1 = mock.MagicMock()
-        mock_req2 = mock.MagicMock()
+
         # Mock PublicIps
         pubip1 = mock.MagicMock()
-        pubip2 = mock.MagicMock()
         pubip1.id = '10.10.10.10'
         pubip1.internal = '9.10.11.12'
-        pubip2.id = '11.11.11.11'
-        pubip2.internal = '13.14.15.16'
-        # Mock Servers
+
+        # Mock Server
         mock_server1 = mock.MagicMock()
         mock_server2 = mock.MagicMock()
         mock_server1.id = 'TESTSVR1'
@@ -54,21 +52,13 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         mock_req1.server = mock_server1
         mock_req1.requests = [mock_req1]
         mock_server1.PublicIPs().Add.return_value = mock_req1
-        mock_server2.id = 'TESTSVR2'
-        mock_server2.data = {'details': {'ipAddresses': [{'internal': '5.6.7.8'}]}}
-        mock_server2.PublicIPs().public_ips = [pubip2]
-        pubip2.Delete.return_value = mock_req2
-        mock_req2.server = mock_server2
-        mock_req2.requests = [mock_req2]
-        mock_server2.PublicIPs().Add.return_value = mock_req2
-        return [mock_server1, mock_server2]
+        return mock_server1
 
 
-    def build_mock_server_list_wo_public_ips(self):
-        mock_server_list = self.build_mock_server_list()
-        for server in mock_server_list:
-            server.PublicIPs().public_ips = []
-        return mock_server_list
+    def build_mock_server_wo_public_ips(self):
+        mock_server = self.build_mock_server()
+        mock_server.PublicIPs().public_ips = []
+        return mock_server
 
     @patch.object(clc_publicip, 'clc_sdk')
     def test_set_user_agent(self, mock_clc_sdk):
@@ -77,37 +67,31 @@ class TestClcPublicIpFunctions(unittest.TestCase):
 
         self.assertTrue(mock_clc_sdk.SetRequestsSession.called)
 
-    def build_mock_publicip_add_request_list(self, mock_server_list=None, status='succeeded'):
-        if mock_server_list is None:
-            mock_server_list = self.build_mock_server_list()
-        assert isinstance(mock_server_list, list), "You must pass a list of mocked servers"
-        assert len(mock_server_list) > 0, "You must pass a list of mocked servers with len > 0"
-        assert mock_server_list[0].PublicIPs().Add()\
-            , "List must contain valid mocked servers with a PublicIPs().Add() function"
+    def build_mock_publicip_add_request(self, mock_server=None, status='succeeded'):
+        if mock_server is None:
+            mock_server = self.build_mock_server()
+        assert mock_server.PublicIPs().Add()\
+            , "Mock must contain valid mocked server with a PublicIPs().Add() function"
 
-        mock_request_list = [server.PublicIPs().Add() for server in mock_server_list]
-        for request in mock_request_list:
-            request.Status.return_value = status
-        return mock_request_list
+        mock_request = server.PublicIPs().Add()
+        mock_request.Status.return_value = status
+        return mock_request
 
 
-    def build_mock_publicip_delete_request_list(self, mock_server_list=None, status = 'succeeded'):
-        if mock_server_list is None:
-            mock_server_list = self.build_mock_server_list()
-        assert isinstance(mock_server_list, list), "You must pass a list of mocked servers"
-        assert len(mock_server_list) > 0, "You must pass a list of mocked servers with len > 0"
-        assert mock_server_list[0].PublicIPs().public_ips[0].Delete()\
-            , "List must contain valid mocked servers with a PublicIPs().Add() function"
+    def build_mock_publicip_delete_request(self, mock_server=None, status = 'succeeded'):
+        if mock_server is None:
+            mock_server = self.build_mock_server()
+        assert mock_server.PublicIPs().public_ips[0].Delete()\
+            , "Mock must contain valid mocked server with a PublicIPs().Add() function"
 
-        mock_request_list = [server.PublicIPs().public_ips[0].Delete() for server in mock_server_list]
-        for request in mock_request_list:
-            request.Status.return_value = status
-        return mock_request_list
+        mock_request = server.PublicIPs().public_ips[0].Delete()
+        mock_request.Status.return_value = status
+        return mock_request
 
 
-    def build_mock_server_id_list(self):
-        mock_server_list = self.build_mock_server_list()
-        return [server.id for server in mock_server_list]
+    def build_mock_server_id(self):
+        mock_server = self.build_mock_server()
+        return mock_server.id
 
 
     def test_clc_module_not_found(self):
@@ -117,10 +101,12 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         def mock_import(name, *args):
             if name == 'clc': raise ImportError
             return real_import(name, *args)
+
         # Under Test
         with mock.patch('__builtin__.__import__', side_effect=mock_import):
             reload(clc_publicip)
             ClcPublicIp(self.module)
+
         # Assert Expected Behavior
         self.module.fail_json.assert_called_with(msg='clc-python-sdk required for this module')
         reload(clc_publicip)
@@ -134,10 +120,12 @@ class TestClcPublicIpFunctions(unittest.TestCase):
             if name == 'requests':
                 args[0]['requests'].__version__ = '2.4.0'
             return real_import(name, *args)
+
         # Under Test
         with mock.patch('__builtin__.__import__', side_effect=mock_import):
             reload(clc_publicip)
             ClcPublicIp(self.module)
+
         # Assert Expected Behavior
         self.module.fail_json.assert_called_with(msg='requests library  version should be >= 2.5.0')
         reload(clc_publicip)
@@ -151,10 +139,12 @@ class TestClcPublicIpFunctions(unittest.TestCase):
                 args[0]['requests'].__version__ = '2.7.0'
                 raise ImportError
             return real_import(name, *args)
+
         # Under Test
         with mock.patch('__builtin__.__import__', side_effect=mock_import):
             reload(clc_publicip)
             ClcPublicIp(self.module)
+
         # Assert Expected Behavior
         self.module.fail_json.assert_called_with(msg='requests library is required for this module')
         reload(clc_publicip)
@@ -197,26 +187,26 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         result = ClcPublicIp._define_module_argument_spec()
         self.assertIsInstance(result, dict)
 
-    def test_wait_for_requests_to_complete_req_successful(self):
-        mock_request_list = self.build_mock_publicip_add_request_list(status='succeeded')
-        under_test = ClcPublicIp(self.module)._wait_for_requests_to_complete
-        under_test(mock_request_list)
+    def test_wait_for_request_to_complete_req_successful(self):
+        mock_request = self.build_mock_publicip_add_request(status='succeeded')
+        under_test = ClcPublicIp(self.module)._wait_for_request_to_complete
+        under_test(mock_request)
         self.assertFalse(self.module.fail_json.called)
 
 
-    def test_wait_for_requests_to_complete_req_failed(self):
-        mock_request_list = self.build_mock_publicip_add_request_list(status='failed')
-        under_test = ClcPublicIp(self.module)._wait_for_requests_to_complete
-        under_test(mock_request_list)
+    def test_wait_for_request_to_complete_req_failed(self):
+        mock_request = self.build_mock_publicip_add_request(status='failed')
+        under_test = ClcPublicIp(self.module)._wait_for_request_to_complete
+        under_test(mock_request)
         self.assertTrue(self.module.fail_json.called)
 
 
     @patch.object(ClcPublicIp, 'clc')
-    def test_get_servers_from_clc_api(self, mock_clc_sdk):
+    def test_get_server_from_clc_api(self, mock_clc_sdk):
         mock_clc_sdk.v2.Servers.side_effect = CLCException("Server Not Found")
         under_test = ClcPublicIp(self.module)
-        under_test._get_servers_from_clc(['TESTSVR1', 'TESTSVR2'], 'FAILED TO OBTAIN LIST')
-        self.module.fail_json.assert_called_once_with(msg='FAILED TO OBTAIN LIST: Server Not Found')
+        under_test._get_server_from_clc('TESTSVR1', 'FAILED TO OBTAIN SERVER')
+        self.module.fail_json.assert_called_once_with(msg='FAILED TO OBTAIN SERVER: Server Not Found')
 
     @patch.object(ClcPublicIp, 'clc')
     def test_add_publicip_to_server_exception(self, mock_clc_sdk):
@@ -251,11 +241,11 @@ class TestClcPublicIpFunctions(unittest.TestCase):
     @patch.object(ClcPublicIp, '_set_clc_credentials_from_env')
     def test_process_request_state_present(self, mock_set_clc_creds, mock_public_ip):
         test_params = {
-            'server_ids': ['TESTSVR1', 'TESTSVR2']
+            'server_id': 'TESTSVR1'
             ,'protocol': 'TCP'
             ,'ports': [80, 90]
             ,'wait': True
-            , 'state': 'present'
+            ,'state': 'present'
         }
         mock_public_ip.return_value = True, ['TESTSVR1'], mock.MagicMock()
         self.module.params = test_params
@@ -264,38 +254,38 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         under_test = ClcPublicIp(self.module)
         under_test.process_request()
 
-        self.module.exit_json.assert_called_once_with(changed=True, server_ids=['TESTSVR1'])
+        self.module.exit_json.assert_called_once_with(changed=True, server_id='TESTSVR1')
         self.assertFalse(self.module.fail_json.called)
 
     @patch.object(ClcPublicIp, 'ensure_public_ip_absent')
     @patch.object(ClcPublicIp, '_set_clc_credentials_from_env')
     def test_process_request_state_absent(self, mock_set_clc_creds, mock_public_ip):
         test_params = {
-            'server_ids': ['TESTSVR1', 'TESTSVR2']
+            'server_id': 'TESTSVR1'
             ,'protocol': 'TCP'
             ,'ports': [80, 90]
             ,'wait': True
-            , 'state': 'absent'
+            ,'state': 'absent'
         }
-        mock_public_ip.return_value = True, ['TESTSVR1','TESTSVR2'], mock.MagicMock()
+        mock_public_ip.return_value = True, 'TESTSVR1', mock.MagicMock()
         self.module.params = test_params
         self.module.check_mode = False
 
         under_test = ClcPublicIp(self.module)
         under_test.process_request()
 
-        self.module.exit_json.assert_called_once_with(changed=True, server_ids=['TESTSVR1', 'TESTSVR2'])
+        self.module.exit_json.assert_called_once_with(changed=True, server_id='TESTSVR1')
         self.assertFalse(self.module.fail_json.called)
 
     @patch.object(ClcPublicIp, 'ensure_public_ip_absent')
     @patch.object(ClcPublicIp, '_set_clc_credentials_from_env')
     def test_process_request_state_invalid(self, mock_set_clc_creds, mock_public_ip):
         test_params = {
-            'server_ids': ['TESTSVR1', 'TESTSVR2']
+            'server_id': 'TESTSVR1'
             ,'protocol': 'TCP'
             ,'ports': [80, 90]
             ,'wait': True
-            , 'state': 'INVALID'
+            ,'state': 'INVALID'
         }
 
         self.module.params = test_params
@@ -306,34 +296,34 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         self.assertFalse(self.module.exit_json.called)
 
     @patch.object(ClcPublicIp, '_get_servers_from_clc')
-    def test_ensure_server_publicip_present_w_mock_server(self,mock_get_servers):
-        server_ids = ['TESTSVR1']
-        mock_get_servers.return_value=[mock.MagicMock()]
+    def test_ensure_server_publicip_present_w_mock_server(self,mock_get_server):
+        server_id = 'TESTSVR1'
+        mock_get_server.return_value=mock.MagicMock()
         protocol = 'TCP'
         ports = [80]
         self.module.check_mode = False
         under_test = ClcPublicIp(self.module)
-        under_test.ensure_public_ip_present(server_ids, protocol, ports)
+        under_test.ensure_public_ip_present(server_id, protocol, ports)
         self.assertFalse(self.module.fail_json.called)
 
     @patch.object(ClcPublicIp, '_get_servers_from_clc')
-    def test_ensure_server_publicip_present_w_mock_server_restrictions(self,mock_get_servers):
-        server_ids = ['TESTSVR1']
-        mock_get_servers.return_value=[mock.MagicMock()]
+    def test_ensure_server_publicip_present_w_mock_server_restrictions(self,mock_get_server):
+        server_id = 'TESTSVR1'
+        mock_get_server.return_value=mock.MagicMock()
         protocol = 'TCP'
         ports = [80]
         restrictions = ['1.1.1.1/24', '2.2.2.0/36']
         self.module.check_mode = False
         under_test = ClcPublicIp(self.module)
-        under_test.ensure_public_ip_present(server_ids=server_ids,
+        under_test.ensure_public_ip_present(server_id=server_id,
                                             protocol=protocol,
                                             ports=ports,
                                             source_restrictions=restrictions)
         self.assertFalse(self.module.fail_json.called)
 
     @patch.object(ClcPublicIp, '_get_servers_from_clc')
-    def test_ensure_server_absent_absent_w_mock_server(self,mock_get_servers):
-        server_ids = ['TESTSVR1']
+    def test_ensure_server_absent_absent_w_mock_server(self,mock_get_server):
+        server_id = ['TESTSVR1']
         mock_server1 = mock.MagicMock()
         mock_server1.id = 'TESTSVR1'
         public_ips_obj = mock.MagicMock()
@@ -341,25 +331,22 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         ip.Delete.return_value = 'success'
         public_ips_obj.public_ips = [ip]
         mock_server1.PublicIPs.return_value = public_ips_obj
-        mock_get_servers.return_value=[mock_server1]
+        mock_get_server.return_value=[mock_server1]
         self.module.check_mode = False
 
         under_test = ClcPublicIp(self.module)
-        changed, servers_modified, requests = under_test.ensure_public_ip_absent(server_ids)
+        changed, servers_modified, requests = under_test.ensure_public_ip_absent(server_id)
         self.assertFalse(self.module.fail_json.called)
         self.assertEqual(changed, True)
         self.assertEqual(servers_modified, ['TESTSVR1'])
 
-    def test_wait_for_requests_w_mock_request(self):
+    def test_wait_for_request_w_mock_request(self):
         mock_r1 = mock.MagicMock()
         mock_r1.WaitUntilComplete.return_value = True
-        mock_r2 = mock.MagicMock()
-        mock_r2.WaitUntilComplete.return_value = True
-        requests = [mock_r1, mock_r2]
         self.module.wait = True
 
         under_test = ClcPublicIp(self.module)
-        under_test._wait_for_requests_to_complete(requests)
+        under_test._wait_for_request_to_complete(mock_r1)
         self.assertFalse(self.module.fail_json.called)
 
     def test_wait_for_requests_w_mock_request_fail(self):
@@ -367,22 +354,21 @@ class TestClcPublicIpFunctions(unittest.TestCase):
         mock_request.WaitUntilComplete.return_value = True
         mock_response = mock.MagicMock()
         mock_response.Status.return_value = 'Failed'
-        mock_request.requests = [mock_response]
-        requests = [mock_request]
+        mock_request.request = mock_response
         self.module.wait = True
 
         under_test = ClcPublicIp(self.module)
-        under_test._wait_for_requests_to_complete(requests)
+        under_test._wait_for_request_to_complete(mock_request)
         self.assertTrue(self.module.fail_json.called)
 
-    def test_wait_for_requests_no_wait(self):
+    def test_wait_for_request_no_wait(self):
         mock_request = mock.MagicMock()
         mock_request.WaitUntilComplete.return_value = True
         self.module.params = {
             'wait': False
         }
         under_test = ClcPublicIp(self.module)
-        under_test._wait_for_requests_to_complete([mock_request])
+        under_test._wait_for_request_to_complete(mock_request)
         self.assertFalse(self.module.fail_json.called)
 
 

--- a/src/unittest/python/test_clc_publicip.py
+++ b/src/unittest/python/test_clc_publicip.py
@@ -339,12 +339,14 @@ class TestClcPublicIpFunctions(unittest.TestCase):
     def test_valid_ports_returns_expected_output(self):
         expected = [
             {'port': 80, 'protocol': 'TCP'},
-            {'port': 34590, 'protocol': 'UDP'}
+            {'port': 34590, 'protocol': 'UDP'},
+            {'port': 1234, 'port_to': 4567, 'protocol': 'TCP'}
         ]
 
         input_data = [
             {'port': 80},
-            {'port': 34590, 'protocol': 'UDP'}
+            {'port': 34590, 'protocol': 'UDP'},
+            {'port': 1234, 'port_to': 4567}
         ]
 
         under_test = ClcPublicIp(self.module)

--- a/standarization.md
+++ b/standarization.md
@@ -1,11 +1,11 @@
 
 
-### Insure that all modules honor CHECK mode:
+### Ensure that all modules honor CHECK mode:
 See http://docs.ansible.com/developing_modules.html#check-mode and https://docs.ansible.com/playbooks_checkmode.html
 
 1.  Pass ```supports_check_mode=True``` when instantiating the AnsibleModule object.
 2.  Place ```if not module.check_mode:``` before any call to the CLC API that would change state.
-3.  Insure that module.exit_json only returns items actually changed from ```changed=```
+3.  Ensure that module.exit_json only returns items actually changed from ```changed=```
 
 ### Standardize wait parameter
 All modules should take ```wait``` as a parameter.  It should default to ```True```.  If wait is set to false, then the 
@@ -60,7 +60,7 @@ See the clc_server module for an example.
 
 ### All Classes and Functions should have docstrings
 
-Insure that all classes and functions should have docstrings that follow the conventions in [PEP257](https://www.python.org/dev/peps/pep-0257/).
+Ensure that all classes and functions should have docstrings that follow the conventions in [PEP257](https://www.python.org/dev/peps/pep-0257/).
 
 ### Add copywrite comment to the beginning of each module
 This should be included in each file at the very beginning, before the DOCUMENTATION string.
@@ -68,31 +68,46 @@ This should be included in each file at the very beginning, before the DOCUMENTA
 ```python
 # CenturyLink Cloud Ansible Modules.
 #
-# These Ansible modules enable the CenturyLink Cloud v2 API to be called# from an within Ansible Playbook.
+# These Ansible modules enable the CenturyLink Cloud v2 API to be called
+# from an within Ansible Playbook.
 #
 # This file is part of CenturyLink Cloud, and is maintained
 # by the Workflow as a Service Team
 #
-# Copyright 2015 CenturyLink Cloud## Licensed under the Apache License, Version 2.0 (the "License");# you may not use this file except in compliance with the License.# You may obtain a copy of the License at##    http://www.apache.org/licenses/LICENSE-2.0## Unless required by applicable law or agreed to in writing, software# distributed under the License is distributed on an "AS IS" BASIS,# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.# See the License for the specific language governing permissions and# limitations under the License.
+# Copyright 2015 CenturyLink Cloud
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # CenturyLink Cloud: http://www.CenturyLinkCloud.com
 # API Documentation: https://www.centurylinkcloud.com/api-docs/v2/
 #
 ```
 
-### Insure the ansible.module_utils.basic import is at the bottom of the file:
+### Ensure the ansible.module_utils.basic import is at the bottom of the file:
 The import should be right before main, not at the top of the file.
 
 Main should be invoked like this:
 ```python
-from ansible.module_utils.basic import *  # pylint: disable=W0614if __name__ == '__main__':    main()
+from ansible.module_utils.basic import *  # pylint: disable=W0614
+if __name__ == '__main__':
+    main()
 ```
 
-### Insure that main() is defined at the bottom of the file
+### Ensure that main() is defined at the bottom of the file
 
 For readability, main should be defined just before it's called.  It should be the last function def in the file.
 
-### Insure that main calls a .process_request() method on a class named for the module
+### Ensure that main calls a .process_request() method on a class named for the module
 
 Example: 
 


### PR DESCRIPTION
Resubmitting per request.  Copy/pasta from the previous PR:

This pull request represents a breaking change to the existing clc_public_ip module.

Now that we've got that out of the way, let me explain what this pull request seeks to accomplish.
1. Restructures module to follow idiomatic, single-resource design (read: it only works on a single server)
2. Adds support for mapping public ip to existing private ip
3. Adds support for specifying port range
4. Addresses issue #19 by collapsing previous protocol and ports attributes into a single list of dictionaries (`ports`) that includes `protocol` (optional, default 'TCP', valid values ['TCP','UDP']), `port` (required), and `port_to` (optional) options
5. Removes 'ICMP' protocol since a) it is always enabled and b) providing it without a port to the python-sdk induces an error
6. Adds full test coverage for new code and additional coverage for existing code
7. Updates all related docs and examples

NOTES:
- I have only tested this on a VM's primary network -- more testing should be done when the secondary NIC functionality is finished
- I have confirmed that multiple public ips can be created as long as a private ip is provided on the second (both?) request(s).  I did not adjust the docs stating that only a single public ip was possible.
