### PR TITLE
Fixed bug where invalid id parameter passed to clc_network_fact results in crash.

### DIFF
--- a/src/main/python/clc_ansible_module/clc_network_fact.py
+++ b/src/main/python/clc_ansible_module/clc_network_fact.py
@@ -189,7 +189,7 @@ class ClcNetworkFact:
         else:
             network = self.networks.Get(requested)
             if network is None:
-                return self.module.fail_json(msg='Network: {0} does not exist'.format(search_key))
+                return self.module.fail_json(msg='Network: "{0}" does not exist'.format(requested))
             self.module.exit_json(network=network.data)
 
     def _get_clc_networks(self, location):


### PR DESCRIPTION
For some reason this referenced a `search_key` variable that is never defined. 
