### PR TITLE
clc_server_snapshot : change to include an option to ignore_failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Executes a blue print package on existing set of servers.
 | `package_params:` | N | {} |  | The arguments required for the package execution.|
 | `state:` | N | `present` | `present` | If `present` module will deploy the package. |
 | `wait:` | N | True | Boolean| Whether to wait for the tasks to finish before returning. |
+| `ignore_failures` | N | False | Boolean | A flag indicating if the failures to be ignored if any of the servers in the list encountered a failure. |
 
 
 ## clc_loadbalancer Module

--- a/src/main/python/clc_ansible_module/clc_server_snapshot.py
+++ b/src/main/python/clc_ansible_module/clc_server_snapshot.py
@@ -390,7 +390,7 @@ class ClcSnapshot:
             server_ids=dict(type='list', required=True),
             expiration_days=dict(default=7),
             wait=dict(default=True),
-            ignore_failures=dict(default=False),
+            ignore_failures=dict(type='bool', default=False),
             state=dict(
                 default='present',
                 choices=[


### PR DESCRIPTION
## Example:
- name: Create a snapshot on a set of servers
  hosts: localhost
  gather_facts: False
  connection: local
  tasks:
  - name: Create server snapshot
    clc_server_snapshot:
      server_ids:
          - UC1WFSDANS01
          - UC1WFSDANS02
      expiration_days: 1
      wait: True
      state: present
      ignore_failures: True
    register: clc
  - name: delete server snapshot
    clc_server_snapshot:
      server_ids:
          - UC1WFSDANS01
          - UC1WFSDANS02
      expiration_days: 1
      wait: True
      state: absent
    register: clc
