### PR TITLE
Rewrite clc_group.py to use native CLC API V2 calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.xml
 nosetests.xml
 target
 build/
+dist/
 *.egg-info/
 .eggs/
 .vagrant/

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 # CenturyLink Cloud Ansible Modules.
 #
 # These Ansible modules enable the CenturyLink Cloud v2 API to be called
@@ -326,7 +325,7 @@ class ClcGroup(object):
                                                       group.id))
         except urllib2.HTTPError as ex:
             self.module.fail_json(msg='Failed to delete group :{0}. {1}'.format(
-                group_name, ex.response_text))
+                group_name, ex))
         return response
 
     def _ensure_group_is_present(
@@ -392,7 +391,7 @@ class ClcGroup(object):
                       'parentGroupId': parent.id})
         except urllib2.HTTPError as ex:
             self.module.fail_json(msg='Failed to create group :{0}. {1}'.format(
-                group_name, ex.response_text))
+                group_name, ex))
         return response
 
     def _group_exists(self, group_name, parent_name):
@@ -522,7 +521,7 @@ class ClcGroup(object):
             return
         for request in requests_lst:
             request.read()
-            if not request.code >= 200 and request.code < 300:
+            if request.code < 200 or request.code >= 300:
                 self.module.fail_json(msg='Unable to process group request')
 
 

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -496,6 +496,16 @@ class ClcGroup(object):
             groups += self._group_by_name_recursive(group_name, child_group)
         return groups
 
+    def _group_full_path(self, group, id=False, delimiter=' / '):
+        path_elements = []
+        while group is not None:
+            if id:
+                path_elements.insert(0, group.id)
+            else:
+                path_elements.insert(0, group.name)
+            group = group.parent
+        return delimiter.join(path_elements)
+
     def _wait_for_requests_to_complete(self, requests_lst):
         """
         Waits until the CLC requests are complete if the wait argument is True

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -222,7 +222,8 @@ group:
 
 __version__ = '${version}'
 
-import clc_ansible_utils.clc
+import clc_ansible_utils.clc as clc_common
+from clc_ansible_utils.clc import ClcApiException
 
 
 class ClcGroup(object):
@@ -233,8 +234,7 @@ class ClcGroup(object):
         """
         Construct module
         """
-        self.clc = clc_ansible_utils.clc
-        self.api = self.clc.ApiV2(module)
+        self.clc_auth = {}
         self.module = module
         self.root_group = None
 
@@ -250,7 +250,7 @@ class ClcGroup(object):
         state = self.module.params.get('state')
 
         # TODO: Initialize credentials from non-private method
-        self.api._set_clc_credentials_from_env()
+        self.clc_auth = clc_common.authenticate(self.module)
         self.root_group = self._get_group_tree_for_datacenter(
             datacenter=location)
 
@@ -319,12 +319,13 @@ class ClcGroup(object):
         group = self._group_by_name(group_name, parent_name=parent_name)
         # TODO: Check for proper HTTP response code
         try:
-            response = self.api.call(
-                'DELETE', '/v2/groups/{0}/{1}'.format(self.api.clc_alias,
-                                                      group.id))
-        except urllib2.HTTPError as ex:
+            response = clc_common.call_clc_api(
+                self.module, self.clc_auth,
+                'DELETE', '/groups/{0}/{1}'.format(
+                    self.clc_auth['clc_alias'], group.id))
+        except ClcApiException as ex:
             self.module.fail_json(msg='Failed to delete group :{0}. {1}'.format(
-                group_name, ex))
+                group_name, ex.message))
         return response
 
     def _ensure_group_is_present(
@@ -384,15 +385,16 @@ class ClcGroup(object):
             description = group_name
         # TODO: Check for proper HTTP response code
         try:
-            response = self.api.call(
-                'POST', '/v2/groups/{0}'.format(self.api.clc_alias),
+            response = clc_common.call_clc_api(
+                self.module, self.clc_auth,
+                'POST', '/groups/{0}'.format(self.clc_auth['clc_alias']),
                 data={'name': group_name, 'description': description,
                       'parentGroupId': parent.id})
             group_data = json.loads(response.read())
-            group = self.clc.Group(group_data)
-        except urllib2.HTTPError as ex:
+            group = clc_common.Group(group_data)
+        except ClcApiException as ex:
             self.module.fail_json(msg='Failed to create group :{0}. {1}'.format(
-                group_name, ex))
+                group_name, ex.message))
         return group
 
     def _group_exists(self, group_name, parent_name):
@@ -418,10 +420,11 @@ class ClcGroup(object):
         :return: Group object for root group containing list of children
         """
         if datacenter is None:
-            datacenter = self.api.clc_location
-        response = self.api.call(
-            'GET', '/v2/datacenters/{0}/{1}'.format(self.api.clc_alias,
-                                                    datacenter),
+            datacenter = self.clc_auth['clc_location']
+        response = clc_common.call_clc_api(
+            self.module, self.clc_auth,
+            'GET', '/datacenters/{0}/{1}'.format(
+                self.clc_auth['clc_alias'], datacenter),
             data={'GroupLinks': 'true'})
 
         r = json.loads(response.read())
@@ -429,9 +432,10 @@ class ClcGroup(object):
                                           for obj in r['links']
                                           if obj['rel'] == "group"][0]
 
-        response = self.api.call(
-            'GET', '/v2/groups/{0}/{1}'.format(self.api.clc_alias,
-                                               root_group_id))
+        response = clc_common.call_clc_api(
+            self.module, self.clc_auth,
+            'GET', '/groups/{0}/{1}'.format(
+                self.clc_auth['clc_alias'], root_group_id))
 
         group_data = json.loads(response.read())
         return self._walk_groups_recursive(None, group_data)
@@ -443,7 +447,7 @@ class ClcGroup(object):
         :param group_data: dict - Dict of data from JSON API return
         :return: Group object from data, containing list of children
         """
-        group = self.clc.Group(group_data)
+        group = clc_common.Group(group_data)
         group.parent = parent_group
         for child_data in group_data['groups']:
             if child_data['type'] != 'default':

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # CenturyLink Cloud Ansible Modules.
 #
@@ -288,10 +289,10 @@ class ClcGroup(object):
             datacenter=location)
 
         if state == "absent":
-            changed, group, requests = self._ensure_group_is_absent(
+            changed, group, requests_lst = self._ensure_group_is_absent(
                 group_name=group_name, parent_name=parent_name)
-            if requests:
-                self._wait_for_requests_to_complete(requests)
+            if requests_lst:
+                self._wait_for_requests_to_complete(requests_lst)
         else:
             changed, group = self._ensure_group_is_present(
                 group_name=group_name, parent_name=parent_name, group_description=group_description)

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -317,7 +317,7 @@ class ClcGroup(object):
         if parent_name is None:
             parent_name = self.root_group.name
         group = clc_common.find_group(self.module, self.root_group,
-                                      group_name, parent_name=parent_name)
+                                      group_name, parent_info=parent_name)
         # TODO: Check for proper HTTP response code
         try:
             response = clc_common.call_clc_api(
@@ -357,7 +357,7 @@ class ClcGroup(object):
 
         if parent_exists and child_exists:
             group = clc_common.find_group(self.module, self.root_group,
-                                          group_name, parent_name=parent_name)
+                                          group_name, parent_info=parent_name)
             changed = False
         elif parent_exists and not child_exists:
             if not self.module.check_mode:
@@ -410,7 +410,7 @@ class ClcGroup(object):
         result = False
         if parent_name:
             group = clc_common.find_group(self.module, self.root_group,
-                                          group_name, parent_name=parent_name)
+                                          group_name, parent_info=parent_name)
         else:
             group = clc_common.find_group(self.module, self.root_group,
                                           group_name)

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -388,12 +388,11 @@ class ClcGroup(object):
             description = group_name
         # TODO: Check for proper HTTP response code
         try:
-            response = clc_common.call_clc_api(
+            group_data = clc_common.call_clc_api(
                 self.module, self.clc_auth,
                 'POST', '/groups/{0}'.format(self.clc_auth['clc_alias']),
                 data={'name': group_name, 'description': description,
                       'parentGroupId': parent.id})
-            group_data = json.loads(response.read())
             group = clc_common.Group(group_data)
         except ClcApiException as ex:
             self.module.fail_json(msg='Failed to create group :{0}. {1}'.format(

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -251,8 +251,8 @@ class ClcGroup(object):
 
         # TODO: Initialize credentials from non-private method
         self.clc_auth = clc_common.authenticate(self.module)
-        self.root_group = self._get_group_tree_for_datacenter(
-            datacenter=location)
+        self.root_group = clc_common.group_tree(self.module, self.clc_auth,
+                                                datacenter=location)
 
         if state == "absent":
             changed, group, requests_lst = self._ensure_group_is_absent(
@@ -316,7 +316,8 @@ class ClcGroup(object):
         response = None
         if parent_name is None:
             parent_name = self.root_group.name
-        group = self._group_by_name(group_name, parent_name=parent_name)
+        group = clc_common.find_group(self.module, self.root_group,
+                                      group_name, parent_name=parent_name)
         # TODO: Check for proper HTTP response code
         try:
             response = clc_common.call_clc_api(
@@ -355,7 +356,8 @@ class ClcGroup(object):
                                           parent_name=parent_name)
 
         if parent_exists and child_exists:
-            group = self._group_by_name(group_name, parent_name=parent_name)
+            group = clc_common.find_group(self.module, self.root_group,
+                                          group_name, parent_name=parent_name)
             changed = False
         elif parent_exists and not child_exists:
             if not self.module.check_mode:
@@ -380,7 +382,8 @@ class ClcGroup(object):
         :return: clc_sdk.Group - the created group
         """
         group = None
-        parent = self._group_by_name(parent_name)
+        parent = clc_common.find_group(self.module, self.root_group,
+                                       parent_name)
         if not description:
             description = group_name
         # TODO: Check for proper HTTP response code
@@ -406,117 +409,14 @@ class ClcGroup(object):
         """
         result = False
         if parent_name:
-            group = self._group_by_name(group_name, parent_name=parent_name)
+            group = clc_common.find_group(self.module, self.root_group,
+                                          group_name, parent_name=parent_name)
         else:
-            group = self._group_by_name(group_name)
+            group = clc_common.find_group(self.module, self.root_group,
+                                          group_name)
         if group:
             result = True
         return result
-
-    def _get_group_tree_for_datacenter(self, datacenter=None):
-        """
-        Walk the tree of groups for a datacenter
-        :param datacenter: string - the datacenter to walk (ex: 'UC1')
-        :return: Group object for root group containing list of children
-        """
-        if datacenter is None:
-            datacenter = self.clc_auth['clc_location']
-        response = clc_common.call_clc_api(
-            self.module, self.clc_auth,
-            'GET', '/datacenters/{0}/{1}'.format(
-                self.clc_auth['clc_alias'], datacenter),
-            data={'GroupLinks': 'true'})
-
-        r = json.loads(response.read())
-        root_group_id, root_group_name = [(obj['id'], obj['name'])
-                                          for obj in r['links']
-                                          if obj['rel'] == "group"][0]
-
-        response = clc_common.call_clc_api(
-            self.module, self.clc_auth,
-            'GET', '/groups/{0}/{1}'.format(
-                self.clc_auth['clc_alias'], root_group_id))
-
-        group_data = json.loads(response.read())
-        return self._walk_groups_recursive(None, group_data)
-
-    def _walk_groups_recursive(self, parent_group, group_data):
-        """
-        Walk a parent-child tree of groups, starting with the provided child group
-        :param parent_group: clc.Group - Parent of group described by group_data
-        :param group_data: dict - Dict of data from JSON API return
-        :return: Group object from data, containing list of children
-        """
-        group = clc_common.Group(group_data)
-        group.parent = parent_group
-        for child_data in group_data['groups']:
-            if child_data['type'] != 'default':
-                continue
-            group.children.append(self._walk_groups_recursive(group, child_data))
-        return group
-
-    def _group_by_name(self, group_name, group=None, parent_name=None):
-        """
-        :param group_name: Name of group to search form
-        :param group: Optional group under which to search
-        :param parent_name:  Optional name of parent
-        :return: Group object found, or None if no groups found.
-        Will return an error if multiple groups found matching parameters.
-        """
-        groups = self._group_by_name_recursive(
-            group_name, group=group, parent_name=parent_name)
-        if len(groups) > 1:
-            error_message = 'Found {0:d} groups with name: \"{1}\"'.format(
-                len(groups), group_name)
-            if parent_name is None:
-                error_message += ' in root group \"{0}\".'.format(
-                    self.root_group.name)
-            else:
-                error_message += ' in group: \"{0}\".'.format(parent_name)
-            error_message += ' Group ids: ' + ', '.join([g.id for g in groups])
-            return self.module.fail_json(msg=error_message)
-        elif len(groups) == 1:
-            return groups[0]
-        else:
-            return None
-
-    def _group_by_name_recursive(self, group_name, group=None,
-                                 parent_name=None):
-        """
-        :param group_name: Name of group to search for
-        :param group: Optional group under which to search
-        :param parent_name: Optional name of parent
-        :return: List of groups found matching the described parameters
-        """
-        groups = []
-        if group is None:
-            group = self.root_group
-        if group_name == group.name:
-            if parent_name is None:
-                groups.append(group)
-            elif group.parent is not None and parent_name == group.parent.name:
-                groups.append(group)
-        for child_group in group.children:
-            groups += self._group_by_name_recursive(group_name,
-                                                    group=child_group,
-                                                    parent_name=parent_name)
-        return groups
-
-    def _group_full_path(self, group, id=False, delimiter=' / '):
-        """
-        :param group: Group object for which to show full ancestry
-        :param id: Optional flag to show group id hierarchy
-        :param delimiter: Optional delimiter
-        :return:
-        """
-        path_elements = []
-        while group is not None:
-            if id:
-                path_elements.insert(0, group.id)
-            else:
-                path_elements.insert(0, group.name)
-            group = group.parent
-        return delimiter.join(path_elements)
 
     def _wait_for_requests_to_complete(self, requests_lst):
         """

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -467,9 +467,11 @@ class ClcGroup(object):
             error_message = 'Found {0:d} groups with name: \"{1}\"'.format(
                 len(groups), group_name)
             if parent_name is None:
-                error_message += ' in root group'
+                error_message += ' in root group \"{0}\".'.format(
+                    self.root_group.name)
             else:
-                error_message += ' in group: \"{0}\"'.format(parent_name)
+                error_message += ' in group: \"{0}\".'.format(parent_name)
+            error_message += ' Group ids: ' + ', '.join([g.id for g in groups])
             return self.module.fail_json(msg=error_message)
         elif len(groups) == 1:
             return groups[0]

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -270,7 +270,7 @@ class ClcGroup(object):
         if requests.__version__ and LooseVersion(requests.__version__) < LooseVersion('2.5.0'):
             self.module.fail_json(
                 msg='requests library  version should be >= 2.5.0')
-        self._headers = {}
+        self._headers = {'Content-Type': 'application/json'}
         self._set_user_agent()
 
     def process_request(self):
@@ -334,7 +334,6 @@ class ClcGroup(object):
             self.v2_api_token = v2_api_token
             self.clc_alias = clc_alias
         elif v2_api_username and v2_api_passwd:
-            self._headers['Content-Type'] = 'application/json'
             try:
                 response = open_url(
                     url=self.api_url + '/v2/authentication/login',
@@ -349,11 +348,10 @@ class ClcGroup(object):
                 return self.module.fail_json(
                     msg='Failed to authenticate with clc V2 api.')
 
-            self._headers['Cookie'] = response.headers.get('Set-Cookie')
-
             r = json.loads(response.read())
             self.v2_api_token = r['bearerToken']
             self.clc_alias = r['accountAlias']
+            self.clc_location = r['locationAlias']
         else:
             return self.module.fail_json(
                 msg="You must set the CLC_V2_API_USERNAME and CLC_V2_API_PASSWD "
@@ -474,28 +472,81 @@ class ClcGroup(object):
         :param datacenter: string - the datacenter to walk (ex: 'UC1')
         :return: a dictionary of groups and parents
         """
+        if datacenter is None:
+            datacenter = self.clc_location
+        # TODO: Remove clc_sdk dependency
+        try:
+            headers = {'Authorization': 'Bearer {0}'.format(
+                self.v2_api_token)}
+            headers.update(self._headers)
+            response = open_url(
+                url='{0}/v2/datacenters/{1}/{2}'.format(
+                    self.api_url, self.clc_alias, datacenter),
+                method='GET',
+                headers=headers,
+                data={'GroupLinks': 'true'})
+        # TODO: Handle different response codes from API
+        except urllib2.HTTPError as ex:
+            return self.module.fail_json(msg=ex)
+        #if response.code not in [200]:
+        #    return self.module.fail_json(
+        #        msg='Failed to authenticate with clc V2 api.')
+
+        r = json.loads(response.read())
+        root_group_id, root_group_name = [(obj['id'], obj['name'])
+                                          for obj in r['links']
+                                          if obj['rel'] == "group"][0]
+
+        try:
+            headers = {'Authorization': 'Bearer {0}'.format(
+                self.v2_api_token)}
+            headers.update(self._headers)
+            response = open_url(
+                url='{0}/v2/groups/{1}/{2}'.format(
+                    self.api_url, self.clc_alias, root_group_id),
+                method='GET',
+                headers=headers)
+        # TODO: Handle different response codes from API
+        except urllib2.HTTPError as ex:
+            return self.module.fail_json(msg=ex)
+
+        self.group_data = json.loads(response.read())
+        # TODO: Replicate functionality of Group.Subgroups()
+        # Basically iterate through all the groups and save off the info
+        # Need to figure out expected data structure
+
+
         self.root_group = self.clc.v2.Datacenter(
             location=datacenter).RootGroup()
         return self._walk_groups_recursive(
             parent_group=None,
             child_group=self.root_group)
 
-    def _walk_groups_recursive(self, parent_group, child_group):
+    def _walk_groups_recursive(self, parent_group, group_data):
         """
         Walk a parent-child tree of groups, starting with the provided child group
         :param parent_group: clc_sdk.Group - the parent group to start the walk
         :param child_group: clc_sdk.Group - the child group to start the walk
         :return: a dictionary of groups and parents
         """
-        result = {str(child_group): (child_group, parent_group)}
-        groups = child_group.Subgroups().groups
-        if len(groups) > 0:
-            for group in groups:
-                if group.type != 'default':
-                    continue
-
-                result.update(self._walk_groups_recursive(child_group, group))
+        group = self._group_object(group_data)
+        result = {group['name']: (group, parent_group)}
+        for child_data in group_data['groups']:
+            if child_data['type'] != 'default':
+                continue
+            result.update(self._walk_groups_recursive(group, child_data))
         return result
+
+    def _group_object(self, group_data):
+        """
+        Construct a group object that maps JSON dictionary values to attributes
+        :param group_data:
+        :return: An object that contains
+        """
+        group = object()
+        for attr in ['id', 'name', 'description', 'type']:
+            setattr(group, attr, group_data[attr])
+        return group
 
     def _wait_for_requests_to_complete(self, requests_lst):
         """

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -461,6 +461,13 @@ class ClcGroup(object):
         return group
 
     def _group_by_name(self, group_name, group=None, parent_name=None):
+        """
+        :param group_name: Name of group to search form
+        :param group: Optional group under which to search
+        :param parent_name:  Optional name of parent
+        :return: Group object found, or None if no groups found.
+        Will return an error if multiple groups found matching parameters.
+        """
         groups = self._group_by_name_recursive(
             group_name, group=group, parent_name=parent_name)
         if len(groups) > 1:
@@ -481,11 +488,10 @@ class ClcGroup(object):
     def _group_by_name_recursive(self, group_name, group=None,
                                  parent_name=None):
         """
-        Returns
         :param group_name: Name of group to search for
         :param group: Optional group under which to search
         :param parent_name: Optional name of parent
-        :return:
+        :return: List of groups found matching the described parameters
         """
         groups = []
         if group is None:
@@ -502,6 +508,12 @@ class ClcGroup(object):
         return groups
 
     def _group_full_path(self, group, id=False, delimiter=' / '):
+        """
+        :param group: Group object for which to show full ancestry
+        :param id: Optional flag to show group id hierarchy
+        :param delimiter: Optional delimiter
+        :return:
+        """
         path_elements = []
         while group is not None:
             if id:

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -63,8 +63,6 @@ options:
     required: False
 requirements:
     - python = 2.7
-    - requests >= 2.5.0
-    - clc-sdk
 author: "CLC Runner (@clc-runner)"
 notes:
     - To use this module, it is required to set the below environment variables which enables access to the

--- a/clc_ansible_module/clc_group.py
+++ b/clc_ansible_module/clc_group.py
@@ -377,7 +377,7 @@ class ClcGroup(object):
         :param description: string - a text description of the group
         :return: clc_sdk.Group - the created group
         """
-        response = None
+        group = None
         parent = self._group_by_name(parent_name)
         if not description:
             description = group_name
@@ -387,10 +387,12 @@ class ClcGroup(object):
                 'POST', '/v2/groups/{0}'.format(self.api.clc_alias),
                 data={'name': group_name, 'description': description,
                       'parentGroupId': parent.id})
+            group_data = json.loads(response.read())
+            group = self._group_from_data(group_data)
         except urllib2.HTTPError as ex:
             self.module.fail_json(msg='Failed to create group :{0}. {1}'.format(
                 group_name, ex))
-        return response
+        return group
 
     def _group_exists(self, group_name, parent_name):
         """
@@ -455,6 +457,7 @@ class ClcGroup(object):
         :return: An object that contains
         """
         group = clc_ansible_utils.clc.Group()
+        group.data = group_data
         for attr in ['id', 'name', 'description', 'type']:
             if attr in group_data:
                 setattr(group, attr, group_data[attr])

--- a/clc_ansible_module/clc_group_fact.py
+++ b/clc_ansible_module/clc_group_fact.py
@@ -31,7 +31,7 @@ module: clc_group_fact
 short_description: Get facts about groups in CenturyLink Cloud.
 description:
   - An Ansible module to retrieve facts about groups in CenturyLink Cloud.
-version_added: "2.0"
+version_added: "2.2"
 options:
   group_id:
     description:
@@ -39,7 +39,6 @@ options:
     required: True
 requirements:
     - python = 2.7
-    - requests >= 2.5.0
 author: "CLC Runner (@clc-runner)"
 notes:
     - To use this module, it is required to set the below environment variables which enables access to the
@@ -187,17 +186,9 @@ server:
                 "status": "active",
                 "type": "default"
             }
-        }
 '''
 
 __version__ = '${version}'
-
-try:
-    import requests
-except ImportError:
-    REQUESTS_FOUND = False
-else:
-    REQUESTS_FOUND = True
 
 
 class ClcGroupFact(object):
@@ -208,10 +199,6 @@ class ClcGroupFact(object):
         """
         self.module = module
 
-        if not REQUESTS_FOUND:
-            self.module.fail_json(
-                msg='requests library is required for this module')
-
     def process_request(self):
         """
         Process the request - Main Code Path
@@ -219,17 +206,24 @@ class ClcGroupFact(object):
         """
         self._set_clc_credentials_from_env()
         group_id = self.module.params.get('group_id')
+        request = None
 
-        r = requests.get(self._get_endpoint(group_id), headers={
-            'Authorization': 'Bearer ' + self.v2_api_token
-        })
+        try:
+            request = open_url(url=self._get_endpoint(group_id),
+                               headers={'Authorization': 'Bearer ' + self.v2_api_token},
+                               method='GET')
+        except Exception as e:
+            self.module.fail_json(
+                msg='Unable to fetch the group facts for group id : {0}. {1}'.format(group_id, e.message)
+            )
 
-        if r.status_code not in [200]:
+        if request.code not in [200]:
             self.module.fail_json(
                 msg='Failed to retrieve group facts: %s' %
                 group_id)
 
-        r = r.json()
+        r = json.loads(request.read())
+        request.close()
         servers = r['servers'] = []
 
         for l in r['links']:
@@ -268,16 +262,18 @@ class ClcGroupFact(object):
 
         elif v2_api_username and v2_api_passwd:
 
-            r = requests.post(self.api_url + '/v2/authentication/login', json={
-                'username': v2_api_username,
-                'password': v2_api_passwd
-            })
+            headers = {"Content-Type": "application/json"}
+            request = open_url(url=self.api_url + '/v2/authentication/login',
+                               method='POST',
+                               headers=headers,
+                               data=json.dumps({'username': v2_api_username,
+                                     'password': v2_api_passwd}))
 
-            if r.status_code not in [200]:
+            if request.code not in [200]:
                 self.module.fail_json(
                     msg='Failed to authenticate with clc V2 api.')
 
-            r = r.json()
+            r = json.loads(request.read())
             self.v2_api_token = r['bearerToken']
             self.clc_alias = r['accountAlias']
 
@@ -297,6 +293,7 @@ def main():
     clc_group_fact = ClcGroupFact(module)
     clc_group_fact.process_request()
 
-from ansible.module_utils.basic import *  # pylint: disable=W0614
+from ansible.module_utils.basic import * # pylint: disable=W0614
+from ansible.module_utils.urls import * # pylint: disable=W0614
 if __name__ == '__main__':
     main()

--- a/clc_ansible_utils/__init__.py
+++ b/clc_ansible_utils/__init__.py
@@ -1,0 +1,1 @@
+__version__ = "${version}"

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -126,7 +126,7 @@ def call_clc_api(module, clc_auth, method, url, headers=None, data=None):
         raise ClcApiException(
             'Error calling CenturyLink Cloud API: {0}'.format(ex.message))
     try:
-        return json.load(response.read())
+        return json.loads(response.read())
     except:
         raise ClcApiException(
             'Error converting CenturyLink Cloud API response to JSON')

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -41,106 +41,6 @@ class ClcApiException(Exception):
     pass
 
 
-class ApiV2(object):
-
-    def __init__(self, module):
-        self.module = module
-        self._headers = {}
-        self._set_user_agent()
-        self._default_api_url = 'https://api.ctl.io'
-
-    def _set_user_agent(self):
-        # Helpful ansible open_url params
-        # data, headers, http-agent
-        agent_string = 'ClcAnsibleModule/' + __version__
-        self._headers['Api-Client'] = agent_string
-        self._headers['User-Agent'] = 'Python-urllib2/{0} {1}'.format(
-            urllib2.__version__, agent_string)
-
-    def _set_clc_credentials_from_env(self):
-        """
-        Set the CLC Credentials on the sdk by reading environment variables
-        :return: none
-        """
-        env = os.environ
-        v2_api_token = env.get('CLC_V2_API_TOKEN', False)
-        v2_api_username = env.get('CLC_V2_API_USERNAME', False)
-        v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
-        clc_alias = env.get('CLC_ACCT_ALIAS', False)
-        self.api_url = env.get('CLC_V2_API_URL', self._default_api_url)
-
-        if v2_api_token and clc_alias:
-            self.v2_api_token = v2_api_token
-            self.clc_alias = clc_alias
-        elif v2_api_username and v2_api_passwd:
-            response = self.call(
-                'POST', '/v2/authentication/login',
-                data={'username': v2_api_username,
-                      'password': v2_api_passwd})
-            if response.code not in [200]:
-                return self.module.fail_json(
-                    msg='Failed to authenticate with clc V2 api.')
-
-            r = json.loads(response.read())
-            self.v2_api_token = r['bearerToken']
-            self.clc_alias = r['accountAlias']
-            self.clc_location = r['locationAlias']
-        else:
-            return self.module.fail_json(
-                msg='You must set the CLC_V2_API_USERNAME and '
-                    'CLC_V2_API_PASSWD environment variables')
-
-    def authenticate(self):
-        """
-        Public method to authenticate against the API
-        :return:
-        """
-        if not hasattr(self, 'v2_api_token') or not self.v2_api_token:
-            self._set_clc_credentials_from_env()
-
-    def call(self, method, url, headers=None, data=None):
-        """
-        Make a request to the CLC API v2.0
-        :param method:
-        :param url:
-        :param headers:
-        :param data:
-        :return response:
-        """
-        supported_methods = ('GET', 'POST', 'CREATE', 'UPDATE', 'DELETE')
-        if method not in supported_methods:
-            raise ValueError('Request method "{0}" not supported'.format(
-                method))
-        if not isinstance(url, str) or not isinstance(url, basestring):
-            raise TypeError('URL for API request must be a string')
-        if headers is None:
-            headers = self._headers
-        if not isinstance(headers, dict):
-            raise TypeError('Headers for API request must be a dict')
-        if data is not None and not isinstance(data, dict):
-            raise TypeError('Data for API request must be a dict')
-        # Obtain Bearer token if we do not already have it
-        if 'authentication/login' not in url:
-            if not hasattr(self, 'v2_api_token') or not self.v2_api_token:
-                self._set_clc_credentials_from_env()
-            headers['Authorization'] = 'Bearer {0}'.format(self.v2_api_token)
-        if data is not None:
-            if method.upper() == 'GET':
-                url += '?' + urllib.urlencode(data)
-                data = None
-            else:
-                data = json.dumps(data)
-                headers['Content-Type'] = 'application/json'
-        try:
-            response = open_url(url='{0}/{1}'.format(self.api_url,
-                                                     url.lstrip('/')),
-                                method=method, headers=headers, data=data)
-        except urllib2.HTTPError as ex:
-            raise ClcApiException(ex.msg)
-
-        return response
-
-
 class Group(object):
 
     def __init__(self):
@@ -150,3 +50,102 @@ class Group(object):
         self.description = None
         self.parent = None
         self.children = []
+
+
+def _default_headers():
+    # Helpful ansible open_url params
+    # data, headers, http-agent
+    headers = {}
+    agent_string = 'ClcAnsibleModule/' + __version__
+    headers['Api-Client'] = agent_string
+    headers['User-Agent'] = 'Python-urllib2/{0} {1}'.format(
+         urllib2.__version__, agent_string)
+    return headers
+
+
+def call_clc_api(module, clc_auth, method, url, headers=None, data=None):
+    """
+    Make a request to the CLC API v2.0
+    :param method:
+    :param url:
+    :param headers:
+    :param data:
+    :return response:
+    """
+    if not isinstance(url, str) or not isinstance(url, basestring):
+        raise TypeError('URL for API request must be a string')
+    if headers is None:
+        headers = _default_headers()
+    elif not isinstance(headers, dict):
+        raise TypeError('Headers for API request must be a dict')
+    else:
+        headers = _default_headers().update(headers)
+    if data is not None and not isinstance(data, dict):
+        raise TypeError('Data for API request must be a dict')
+    # Obtain Bearer token if we do not already have it
+    if 'authentication/login' not in url:
+        if 'v2_api_token' not in clc_auth:
+            clc_auth = authenticate(module)
+        headers['Authorization'] = 'Bearer {0}'.format(clc_auth['v2_api_token'])
+    if data is not None:
+        if method.upper() == 'GET':
+            url += '?' + urllib.urlencode(data)
+            data = None
+        else:
+            data = json.dumps(data)
+            headers['Content-Type'] = 'application/json'
+    try:
+        response = open_url(
+            url='{0}/{1}'.format(clc_auth['v2_api_url'].rstrip('/'),
+                                 url.lstrip('/')),
+            method=method,
+            headers=headers,
+            data=data)
+    except urllib2.HTTPError as ex:
+        raise ClcApiException(
+            'Error calling CenturyLink Cloud API: {0}'.format(ex.message))
+    return response
+
+
+def authenticate(module):
+    """
+    Authenticate against the CLC V2 API
+    :param module: Ansible module being called
+    :return: clc_auth - dict containing the needed parameters for authentication
+    """
+    v2_api_url = 'https://api.ctl.io/v2/'
+    env = os.environ
+    v2_api_token = env.get('CLC_V2_API_TOKEN', False)
+    v2_api_username = env.get('CLC_V2_API_USERNAME', False)
+    v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
+    clc_alias = env.get('CLC_ACCT_ALIAS', False)
+    clc_location = env.get('CLC_LOCATION', False)
+    v2_api_url = env.get('CLC_V2_API_URL', v2_api_url)
+    clc_auth = {'v2_api_url': v2_api_url}
+    # Populate clc_auth, authenticating if needed
+    if v2_api_token and clc_alias and clc_location:
+        clc_auth.update({
+            'v2_api_token': v2_api_token,
+            'clc_alias': clc_alias,
+            'clc_location': clc_location,
+        })
+    elif v2_api_username and v2_api_passwd:
+        response = call_clc_api(
+            module, clc_auth,
+            'POST', '/authentication/login',
+            data={'username': v2_api_username,
+                  'password': v2_api_passwd})
+        if response.code not in [200]:
+            return module.fail_json(
+                msg='Failed to authenticate with clc V2 api.')
+        r = json.loads(response.read())
+        clc_auth.update({
+            'v2_api_token': r['bearerToken'],
+            'clc_alias': r['accountAlias'],
+            'clc_location': r['locationAlias']
+        })
+    else:
+        return module.fail_json(
+            msg='You set the CLC_V2_API_USERNAME and '
+                'CLC_V2_API_PASSWD environment variables')
+    return clc_auth

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -131,10 +131,16 @@ class ApiV2(object):
 
 class Group(object):
 
-    def __init__(self):
+    def __init__(self, group_data):
         self.alias = None
         self.id = None
         self.name = None
         self.description = None
         self.parent = None
         self.children = []
+        if group_data is not None:
+            self.data = group_data
+            for attr in ['id', 'name', 'description', 'type']:
+                if attr in group_data:
+                    setattr(self, attr, group_data[attr])
+

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -86,6 +86,14 @@ class ApiV2(object):
                 msg='You must set the CLC_V2_API_USERNAME and '
                     'CLC_V2_API_PASSWD environment variables')
 
+    def authenticate(self):
+        """
+        Public method to authenticate against the API
+        :return:
+        """
+        if not hasattr(self, 'v2_api_token') or not self.v2_api_token:
+            self._set_clc_credentials_from_env()
+
     def call(self, method, url, headers=None, data=None):
         """
         Make a request to the CLC API v2.0

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# CenturyLink Cloud Ansible Modules.
+#
+# These Ansible modules enable the CenturyLink Cloud v2 API to be called
+# from an within Ansible Playbook.
+#
+# This file is part of CenturyLink Cloud, and is maintained
+# by the Workflow as a Service Team
+#
+# Copyright 2015 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CenturyLink Cloud: http://www.CenturyLinkCloud.com
+# API Documentation: https://www.centurylinkcloud.com/api-docs/v2/
+#
+
+__version__ = '${version}'
+
+import os
+import json
+import urllib
+
+from ansible.module_utils.basic import *  # pylint: disable=W0614
+from ansible.module_utils.urls import *  # pylint: disable=W0614
+
+
+class ApiV2(object):
+
+    def __init__(self, module):
+        self.module = module
+        self._headers = {}
+        self._set_user_agent()
+        self._default_api_url = 'https://api.ctl.io'
+
+    def _set_user_agent(self):
+        # Helpful ansible open_url params
+        # data, headers, http-agent
+        agent_string = 'ClcAnsibleModule/' + __version__
+        self._headers['Api-Client'] = agent_string
+        self._headers['User-Agent'] = 'Python-urllib2/{0} {1}'.format(
+            urllib2.__version__, agent_string)
+
+    def _set_clc_credentials_from_env(self):
+        """
+        Set the CLC Credentials on the sdk by reading environment variables
+        :return: none
+        """
+        env = os.environ
+        v2_api_token = env.get('CLC_V2_API_TOKEN', False)
+        v2_api_username = env.get('CLC_V2_API_USERNAME', False)
+        v2_api_passwd = env.get('CLC_V2_API_PASSWD', False)
+        clc_alias = env.get('CLC_ACCT_ALIAS', False)
+        self.api_url = env.get('CLC_V2_API_URL', self._default_api_url)
+
+        if v2_api_token and clc_alias:
+            self.v2_api_token = v2_api_token
+            self.clc_alias = clc_alias
+        elif v2_api_username and v2_api_passwd:
+            response = self.call(
+                'POST', '/v2/authentication/login',
+                data={'username': v2_api_username,
+                      'password': v2_api_passwd})
+            if response.code not in [200]:
+                return self.module.fail_json(
+                    msg='Failed to authenticate with clc V2 api.')
+
+            r = json.loads(response.read())
+            self.v2_api_token = r['bearerToken']
+            self.clc_alias = r['accountAlias']
+            self.clc_location = r['locationAlias']
+        else:
+            return self.module.fail_json(
+                msg='You must set the CLC_V2_API_USERNAME and '
+                    'CLC_V2_API_PASSWD environment variables')
+
+    def call(self, method, url, headers=None, data=None):
+        """
+        Make a request to the CLC API v2.0
+        :param method:
+        :param url:
+        :param headers:
+        :param data:
+        :return response:
+        """
+        supported_methods = ('GET', 'POST', 'CREATE', 'UPDATE', 'DELETE')
+        if method not in supported_methods:
+            raise ValueError('Request method "{0}" not supported'.format(
+                method))
+        if not isinstance(url, str) or not isinstance(url, basestring):
+            raise TypeError('URL for API request must be a string')
+        if headers is None:
+            headers = self._headers
+        if not isinstance(headers, dict):
+            raise TypeError('Headers for API request must be a dict')
+        if data is not None and not isinstance(data, dict):
+            raise TypeError('Data for API request must be a dict')
+        # Obtain Bearer token if we do not already have it
+        if 'authentication/login' not in url:
+            if not hasattr(self, 'v2_api_token') or not self.v2_api_token:
+                self._set_clc_credentials_from_env()
+            headers['Authorization'] = 'Bearer {0}'.format(self.v2_api_token)
+        if data is not None:
+            if method.upper() == 'GET':
+                url += '?' + urllib.urlencode(data)
+                data = None
+            else:
+                data = json.dumps(data)
+                headers['Content-Type'] = 'application/json'
+        try:
+            response = open_url(url='{0}/{1}'.format(self.api_url,
+                                                     url.lstrip('/')),
+                                method=method, headers=headers, data=data)
+        except urllib2.HTTPError as ex:
+            raise
+
+        return response
+
+
+class Group(object):
+
+    def __init__(self):
+        self.alias = None
+        self.id = None
+        self.name = None
+        self.description = None
+        self.parent = None
+        self.children = []

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -187,7 +187,7 @@ def group_tree(module, clc_auth, datacenter=None):
     response = call_clc_api(
         module, clc_auth,
         'GET', '/datacenters/{0}/{1}'.format(
-            self.clc_auth['clc_alias'], datacenter),
+            clc_auth['clc_alias'], datacenter),
         data={'GroupLinks': 'true'})
 
     r = json.loads(response.read())

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -174,7 +174,7 @@ def _walk_groups(parent_group, group_data):
     return group
 
 
-def group_tree(module, clc_auth, datacenter=None):
+def group_tree(module, clc_auth, alias=None, datacenter=None):
     """
     Walk the tree of groups for a datacenter
     :param module: Ansible module being called
@@ -184,10 +184,12 @@ def group_tree(module, clc_auth, datacenter=None):
     """
     if datacenter is None:
         datacenter = clc_auth['clc_location']
+    if alias is None:
+        alias = clc_auth['clc_alias']
     response = call_clc_api(
         module, clc_auth,
         'GET', '/datacenters/{0}/{1}'.format(
-            clc_auth['clc_alias'], datacenter),
+            alias, datacenter),
         data={'GroupLinks': 'true'})
 
     r = json.loads(response.read())
@@ -198,7 +200,7 @@ def group_tree(module, clc_auth, datacenter=None):
     response = call_clc_api(
         module, clc_auth,
         'GET', '/groups/{0}/{1}'.format(
-            clc_auth['clc_alias'], root_group_id))
+            alias, root_group_id))
 
     group_data = json.loads(response.read())
     return _walk_groups(None, group_data)

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -43,13 +43,18 @@ class ClcApiException(Exception):
 
 class Group(object):
 
-    def __init__(self):
+    def __init__(self, group_data):
         self.alias = None
         self.id = None
         self.name = None
         self.description = None
         self.parent = None
         self.children = []
+        if group_data is not None:
+            self.data = group_data
+            for attr in ['id', 'name', 'description', 'type']:
+                if attr in group_data:
+                    setattr(self, attr, group_data[attr])
 
 
 def _default_headers():
@@ -66,11 +71,13 @@ def _default_headers():
 def call_clc_api(module, clc_auth, method, url, headers=None, data=None):
     """
     Make a request to the CLC API v2.0
-    :param method:
-    :param url:
-    :param headers:
-    :param data:
-    :return response:
+    :param module: Ansible module being called
+    :param clc_auth: dict containing the needed parameters for authentication
+    :param method: HTTP method
+    :param url: URL string to be appended to root api_url
+    :param headers: Headers to be added to request
+    :param data: Data to be sent with request
+    :return response: HTTP response from urllib2.urlopen
     """
     if not isinstance(url, str) or not isinstance(url, basestring):
         raise TypeError('URL for API request must be a string')
@@ -149,3 +156,113 @@ def authenticate(module):
             msg='You set the CLC_V2_API_USERNAME and '
                 'CLC_V2_API_PASSWD environment variables')
     return clc_auth
+
+
+def _walk_groups(parent_group, group_data):
+    """
+    Walk a parent-child tree of groups, starting with the provided child group
+    :param parent_group: Group - Parent of group described by group_data
+    :param group_data: dict - Dict of data from JSON API return
+    :return: Group object from data, containing list of children
+    """
+    group = Group(group_data)
+    group.parent = parent_group
+    for child_data in group_data['groups']:
+        if child_data['type'] != 'default':
+            continue
+        group.children.append(_walk_groups(group, child_data))
+    return group
+
+
+def group_tree(module, clc_auth, datacenter=None):
+    """
+    Walk the tree of groups for a datacenter
+    :param module: Ansible module being called
+    :param clc_auth: dict containing the needed parameters for authentication
+    :param datacenter: string - the datacenter to walk (ex: 'UC1')
+    :return: Group object for root group containing list of children
+    """
+    if datacenter is None:
+        datacenter = clc_auth['clc_location']
+    response = call_clc_api(
+        module, clc_auth,
+        'GET', '/datacenters/{0}/{1}'.format(
+            self.clc_auth['clc_alias'], datacenter),
+        data={'GroupLinks': 'true'})
+
+    r = json.loads(response.read())
+    root_group_id, root_group_name = [(obj['id'], obj['name'])
+                                      for obj in r['links']
+                                      if obj['rel'] == "group"][0]
+
+    response = call_clc_api(
+        module, clc_auth,
+        'GET', '/groups/{0}/{1}'.format(
+            clc_auth['clc_alias'], root_group_id))
+
+    group_data = json.loads(response.read())
+    return _walk_groups(None, group_data)
+
+
+def _find_group_recursive(search_group, group_name, parent_name=None):
+    """
+    :param search_group: Group under which to search
+    :param group_name: Name of group to search for
+    :param parent_name: Optional name of parent
+    :return: List of groups found matching the described parameters
+    """
+    groups = []
+    if group_name == search_group.name:
+        if parent_name is None:
+            groups.append(search_group)
+        elif (search_group.parent is not None and
+                parent_name == search_group.parent.name):
+            groups.append(search_group)
+    for child_group in search_group.children:
+        groups += _find_group_recursive(child_group, group_name,
+                                        parent_name=parent_name)
+    return groups
+
+
+def find_group(module, search_group, group_name, parent_name=None):
+    """
+    :param module: Ansible module being called
+    :param search_group: Group under which to search
+    :param group_name: Name of group to search form
+    :param parent_name:  Optional name of parent
+    :return: Group object found, or None if no groups found.
+    Will return an error if multiple groups found matching parameters.
+    """
+    groups = _find_group_recursive(
+        search_group, group_name, parent_name=parent_name)
+    if len(groups) > 1:
+        error_message = 'Found {0:d} groups with name: \"{1}\"'.format(
+            len(groups), group_name)
+        if parent_name is None:
+            error_message += ', no parent group specified.'
+        else:
+            error_message += ' in group: \"{0}\".'.format(parent_name)
+        error_message += ' Group ids: ' + ', '.join([g.id for g in groups])
+        return module.fail_json(msg=error_message)
+    elif len(groups) == 1:
+        return groups[0]
+    else:
+        return None
+
+
+def group_path(group, group_id=False, delimiter='/'):
+    """
+    :param group: Group object for which to show full ancestry
+    :param group_id: Optional flag to show group id hierarchy
+    :param delimiter: Optional delimiter
+    :return:
+    """
+    path_elements = []
+    while group is not None:
+        if group_id:
+            path_elements.append(group.id)
+        else:
+            path_elements.append(group.name)
+        group = group.parent
+    return delimiter.join(reversed(path_elements))
+

--- a/clc_ansible_utils/clc.py
+++ b/clc_ansible_utils/clc.py
@@ -37,6 +37,10 @@ from ansible.module_utils.basic import *  # pylint: disable=W0614
 from ansible.module_utils.urls import *  # pylint: disable=W0614
 
 
+class ClcApiException(Exception):
+    pass
+
+
 class ApiV2(object):
 
     def __init__(self, module):
@@ -132,7 +136,7 @@ class ApiV2(object):
                                                      url.lstrip('/')),
                                 method=method, headers=headers, data=data)
         except urllib2.HTTPError as ex:
-            raise
+            raise ClcApiException(ex.msg)
 
         return response
 

--- a/example-playbooks/deploy-servers-to-maint-grp-size.yml
+++ b/example-playbooks/deploy-servers-to-maint-grp-size.yml
@@ -39,15 +39,15 @@
 
     - name: Wait for SSH to Come up on New Servers
       wait_for: host={{ item.ipaddress }} port=22 delay=5 timeout=320 state=started
-      with_items: clc.servers
+      with_items: {{ clc.servers }}
 
     - name: Update known_hosts With New Servers
       shell: "ssh-keygen -R {{ item.ipaddress }} && ssh-keyscan -t rsa -H {{ item.ipaddress }} >> ~/.ssh/known_hosts"
-      with_items: clc.servers
+      with_items: {{ clc.servers }}
 
     - name: Deploy Ssh Key to New Servers
       shell: "echo '{{ public_key }}'|sshpass -p '{{ serverpass.stdout }}' ssh root@{{ item.ipaddress }} 'cat >> ~/.ssh/authorized_keys'"
-      with_items: clc.servers
+      with_items: {{ clc.servers }}
 
     - name: Add New Servers to the newservers Group
       add_host:
@@ -55,7 +55,7 @@
         ansible_ssh_host={{ item.ipaddress }}
         ansible_ssh_user=root
         groupname=newservers
-      with_items: clc.servers
+      with_items: {{ clc.servers }}
 
 - name: Add Deployment User
   hosts: newservers

--- a/example-playbooks/example_start_sever_push_key_install_software.yml
+++ b/example-playbooks/example_start_sever_push_key_install_software.yml
@@ -17,16 +17,16 @@
     - name: Wait for SSH to Come up on Started Servers
       wait_for: host={{ item.details.ipAddresses[0].internal }} port=22 delay=5 timeout=320 state=started
       with_flattened:
-        - start_server.servers
+        - {{ start_server.servers }}
 
     - name: Update known_hosts With Started Server
       shell: "ssh-keygen -R {{ item.details.ipAddresses[0].internal }} && ssh-keyscan -t rsa -H {{ item.details.ipAddresses[0].internal }} >> ~/.ssh/known_hosts"
-      with_items: start_server.servers
+      with_items: {{ start_server.servers }}
 
     - name: Deploy SSH Key to New Servers (Ubuntu)
       shell: "echo '{{ public_key }}'|sshpass -p '{{ server_password }}' ssh root@{{ item.details.ipAddresses[0].internal }} 'cat >> ~/.ssh/authorized_keys'"
       with_flattened:
-        - start_server.servers
+        - {{ start_server.servers }}
 
     - name: Add New Servers to an in-memory Group
       add_host:
@@ -34,7 +34,7 @@
         ansible_ssh_host={{ item.details.ipAddresses[0].internal }}
         ansible_ssh_user=root
         groupname=SERVERS_GRP
-      with_items: start_server.servers
+      with_items: {{ start_server.servers }}
 
 - name: Install Some Stuff
   hosts: SERVERS_GRP

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible==2.0.2.0
-clc-sdk==2.44
+ansible>=2.1
+clc-sdk>=2.45
 coverage
 future
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible==2.0.2.0
-clc-sdk==2.44
+ansible>=2.0.2.0
+clc-sdk>=2.44
 coverage
 future
 mock

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,15 @@ except ImportError:
 
 setup(
     name='clc-ansible-module',
-    version='1.1.17',
+    version='1.2.0',
     description='Centurylink Cloud Ansible Modules',
     author='CenturyLink Cloud',
     author_email='WFAAS-LLFT@centurylink.com',
     url='https://github.com/CenturylinkCloud/clc-ansible-module',
     download_url='https://github.com/CenturylinkCloud/clc-ansible-module.git',
     install_requires=[
-        'ansible==2.0.2.0',
-        'clc-sdk==2.44',
+        'ansible>=2.0.2.0',
+        'clc-sdk>=2.44',
         'future',
         'mock',
         'nose',

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
     url='https://github.com/CenturylinkCloud/clc-ansible-module',
     download_url='https://github.com/CenturylinkCloud/clc-ansible-module.git',
     install_requires=[
-        'ansible==2.0.2.0',
-        'clc-sdk==2.44',
+        'ansible>=2.0.2.0',
+        'clc-sdk>=2.44',
         'future',
         'mock',
         'nose',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 
 setup(
     name='clc-ansible-module',
-    version='1.1.17',
+    version='1.2.0',
     description='Centurylink Cloud Ansible Modules',
     author='CenturyLink Cloud',
     author_email='WFAAS-LLFT@centurylink.com',

--- a/tests/test_clc.py
+++ b/tests/test_clc.py
@@ -49,7 +49,8 @@ class TestClcApiFunctions(unittest.TestCase):
 
         self.assertEqual(self.module.fail_json.called, True)
 
-    def test_override_v2_api_url_from_environment(self):
+    @patch.object(ApiV2, 'call')
+    def test_override_v2_api_url_from_environment(self, mock_call):
         under_test = ApiV2(self.module)
         original_url = under_test._default_api_url
 

--- a/tests/test_clc.py
+++ b/tests/test_clc.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Copyright 2015 CenturyLink
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import clc_ansible_utils.clc as clc
+from clc_ansible_utils.clc import ApiV2
+
+import mock
+from mock import patch
+import unittest
+
+
+class TestClcApiFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.clc = mock.MagicMock()
+        self.module = mock.MagicMock()
+        self.datacenter = mock.MagicMock()
+
+    def test_clc_set_credentials_w_creds(self):
+        under_test = ApiV2(self.module)
+        with patch.object(under_test, 'call') as mock_method:
+            with patch.dict('os.environ',
+                            {'CLC_V2_API_USERNAME': 'dummy_username',
+                            'CLC_V2_API_PASSWD': 'dummy_passwd'},
+                            clear=True):
+                under_test._set_clc_credentials_from_env()
+        # Should fail with an HTTP error code of 400 for bad user/passwd
+        # TODO: Set up better mock to fully test response from API
+        mock_method.assert_called_with(
+            'POST', '/v2/authentication/login',
+            data={'username': 'dummy_username', 'password': 'dummy_passwd'})
+
+    def test_clc_set_credentials_w_no_creds(self):
+        with patch.dict('os.environ', {}, clear=True):
+            under_test = ApiV2(self.module)
+            under_test._set_clc_credentials_from_env()
+
+        self.assertEqual(self.module.fail_json.called, True)
+
+    def test_override_v2_api_url_from_environment(self):
+        under_test = ApiV2(self.module)
+        original_url = under_test._default_api_url
+
+        under_test._set_clc_credentials_from_env()
+        self.assertEqual(under_test._default_api_url, original_url)
+
+        with patch.dict('os.environ',
+                        {'CLC_V2_API_URL': 'http://unittest.example.com/'},
+                        clear=True):
+            under_test._set_clc_credentials_from_env()
+
+        self.assertEqual(under_test.api_url,
+                         'http://unittest.example.com/')
+
+    def test_set_user_agent(self):
+        under_test = ApiV2(self.module)
+        self.assertTrue(hasattr(under_test, '_headers'))
+        under_test._set_user_agent()
+        self.assertIn('ClcAnsibleModule', under_test._headers['Api-Client'])
+        self.assertIn('ClcAnsibleModule', under_test._headers['User-Agent'])

--- a/tests/test_clc.py
+++ b/tests/test_clc.py
@@ -13,61 +13,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import clc_ansible_utils.clc as clc
-from clc_ansible_utils.clc import ApiV2
+import clc_ansible_utils.clc as clc_common
+from clc_ansible_utils.clc import ClcApiException
 
 import mock
 from mock import patch
 import unittest
 
 
-class TestClcApiFunctions(unittest.TestCase):
+class TestClcCommonFunctions(unittest.TestCase):
 
     def setUp(self):
         self.clc = mock.MagicMock()
         self.module = mock.MagicMock()
         self.datacenter = mock.MagicMock()
 
-    def test_clc_set_credentials_w_creds(self):
-        under_test = ApiV2(self.module)
-        with patch.object(under_test, 'call') as mock_method:
+    def test_authenticate_w_creds(self):
+        with patch.object(clc_common, 'call_clc_api') as mock_method:
             with patch.dict('os.environ',
                             {'CLC_V2_API_USERNAME': 'dummy_username',
                             'CLC_V2_API_PASSWD': 'dummy_passwd'},
                             clear=True):
-                under_test._set_clc_credentials_from_env()
+                clc_common.authenticate(self.module)
         # Should fail with an HTTP error code of 400 for bad user/passwd
+        test_clc_auth = {
+            'v2_api_url': 'https://api.ctl.io/v2/',
+        }
         # TODO: Set up better mock to fully test response from API
         mock_method.assert_called_with(
-            'POST', '/v2/authentication/login',
+            self.module, test_clc_auth,
+            'POST', '/authentication/login',
             data={'username': 'dummy_username', 'password': 'dummy_passwd'})
 
-    def test_clc_set_credentials_w_no_creds(self):
+    def test_authenticate_w_no_creds(self):
         with patch.dict('os.environ', {}, clear=True):
-            under_test = ApiV2(self.module)
-            under_test._set_clc_credentials_from_env()
-
+            clc_common.authenticate(self.module)
         self.assertEqual(self.module.fail_json.called, True)
 
-    @patch.object(ApiV2, 'call')
-    def test_override_v2_api_url_from_environment(self, mock_call):
-        under_test = ApiV2(self.module)
-        original_url = under_test._default_api_url
-
-        under_test._set_clc_credentials_from_env()
-        self.assertEqual(under_test._default_api_url, original_url)
-
+    def test_override_v2_api_url_from_environment(self):
+        original_url = 'https://api.ctl.io/v2/'
+        clc_auth = clc_common.authenticate(self.module)
+        self.assertEqual(clc_auth['v2_api_url'], original_url)
         with patch.dict('os.environ',
-                        {'CLC_V2_API_URL': 'http://unittest.example.com/'},
+                        {'CLC_V2_API_URL': 'http://unittest.example.com/',
+                         'CLC_V2_API_TOKEN': 'dummy_token',
+                         'CLC_ACCT_ALIAS': 'dummy_alias',
+                         'CLC_LOCATION': 'dummy_location'},
                         clear=True):
-            under_test._set_clc_credentials_from_env()
-
-        self.assertEqual(under_test.api_url,
-                         'http://unittest.example.com/')
+            clc_auth = clc_common.authenticate(self.module)
+        self.assertEqual(clc_auth['v2_api_url'], 'http://unittest.example.com/')
 
     def test_set_user_agent(self):
-        under_test = ApiV2(self.module)
-        self.assertTrue(hasattr(under_test, '_headers'))
-        under_test._set_user_agent()
-        self.assertIn('ClcAnsibleModule', under_test._headers['Api-Client'])
-        self.assertIn('ClcAnsibleModule', under_test._headers['User-Agent'])
+        headers = clc_common._default_headers()
+        self.assertIn('ClcAnsibleModule', headers['Api-Client'])
+        self.assertIn('ClcAnsibleModule', headers['User-Agent'])

--- a/tests/test_clc_group.py
+++ b/tests/test_clc_group.py
@@ -94,58 +94,16 @@ class TestClcServerFunctions(unittest.TestCase):
         # Reset clc_group
         reload(clc_group)
 
-    def test_clc_set_credentials_w_creds(self):
-        under_test = ClcGroup(self.module)
-        with patch.dict('os.environ',
-                        {'CLC_V2_API_USERNAME': 'dummy_username',
-                         'CLC_V2_API_PASSWD': 'dummy_passwd'},
-                        clear=True):
-            under_test._set_clc_credentials_from_env()
-        # Should fail with an HTTP error code of 400 for bad user/passwd
-        # TODO: Set up better mock to fully test response from API
-        self.assertEqual(self.module.fail_json.called, True)
-
-    def test_clc_set_credentials_w_no_creds(self):
-        with patch.dict('os.environ', {}, clear=True):
-            under_test = ClcGroup(self.module)
-            under_test._set_clc_credentials_from_env()
-
-        self.assertEqual(self.module.fail_json.called, True)
-
-    def test_override_v2_api_url_from_environment(self):
-        original_url = clc_sdk.defaults.ENDPOINT_URL_V2
-        under_test = ClcGroup(self.module)
-
-        under_test._set_clc_credentials_from_env()
-        self.assertEqual(clc_sdk.defaults.ENDPOINT_URL_V2, original_url)
-
-        with patch.dict('os.environ',
-                        {'CLC_V2_API_URL': 'http://unittest.example.com/'},
-                        clear=True):
-            under_test._set_clc_credentials_from_env()
-
-        self.assertEqual(under_test.api_url,
-                         'http://unittest.example.com/')
-
-        clc_sdk.defaults.ENDPOINT_URL_V2 = original_url
-
-    def test_set_user_agent(self):
-        under_test = ClcGroup(self.module)
-        self.assertTrue(hasattr(under_test, '_headers'))
-        under_test._set_user_agent()
-        self.assertIn('ClcAnsibleModule', under_test._headers['Api-Client'])
-        self.assertIn('ClcAnsibleModule', under_test._headers['User-Agent'])
-
     @patch.object(ClcGroup, 'clc')
     def test_set_clc_credentials_from_env(self, mock_clc_sdk):
         with patch.dict('os.environ', {'CLC_V2_API_TOKEN': 'dummyToken',
                                        'CLC_ACCT_ALIAS': 'TEST'},
                         clear=True):
             under_test = ClcGroup(self.module)
-            under_test._set_clc_credentials_from_env()
-        self.assertEqual(under_test.v2_api_token, 'dummyToken')
-        self.assertEqual(under_test.clc_alias, 'TEST')
-        self.assertEqual(self.module.fail_json.called, False)
+            #under_test._set_clc_credentials_from_env()
+        #self.assertEqual(under_test.v2_api_token, 'dummyToken')
+        #self.assertEqual(under_test.clc_alias, 'TEST')
+        #self.assertEqual(self.module.fail_json.called, False)
 
     def test_define_argument_spec(self):
         result = ClcGroup._define_module_argument_spec()

--- a/tests/test_clc_group.py
+++ b/tests/test_clc_group.py
@@ -43,20 +43,8 @@ class TestClcGroupFunctions(unittest.TestCase):
         result = ClcGroup._define_module_argument_spec()
         self.assertIsInstance(result, dict)
 
-    def test_walk_groups_recursive(self):
-        group_data = {'name': 'Mock Group', 'id': 'mock_id',
-                      'type': 'mock_type', 'groups': []}
-        grp1 = mock.MagicMock()
-        grp1.type = 'default'
-        grp1.children = []
-        under_test = ClcGroup(self.module)
-        res = under_test._walk_groups_recursive(grp1, group_data)
-        self.assertIsNotNone(res)
-
     @patch.object(clc_group, 'clc_common')
-    @patch.object(ClcGroup, '_get_group_tree_for_datacenter')
-    def test_process_request_state_present(self, mock_group_tree,
-                                           mock_clc_common):
+    def test_process_request_state_present(self, mock_clc_common):
         self.module.params = {
             'location': 'UC1',
             'name': 'MyCoolGroup',
@@ -82,9 +70,7 @@ class TestClcGroupFunctions(unittest.TestCase):
             group=mock_group.data)
 
     @patch.object(clc_group, 'clc_common')
-    @patch.object(ClcGroup, '_get_group_tree_for_datacenter')
-    def test_process_request_state_absent(self, mock_group_tree,
-                                          mock_clc_common):
+    def test_process_request_state_absent(self, mock_clc_common):
         self.module.params = {
             'location': 'UC1',
             'name': 'MyCoolGroup',

--- a/tests/test_clc_group_fact.py
+++ b/tests/test_clc_group_fact.py
@@ -31,26 +31,6 @@ class TestClcGroupFactFunctions(unittest.TestCase):
         self.module = mock.MagicMock()
         self.datacenter = mock.MagicMock()
 
-    def test_requests_module_not_found(self):
-        # Setup Mock Import Function
-        real_import = __import__
-
-        def mock_import(name, *args):
-            if name == 'requests':
-                args[0]['requests'].__version__ = '2.7.0'
-                raise ImportError
-            return real_import(name, *args)
-        # Under Test
-        with mock.patch('__builtin__.__import__', side_effect=mock_import):
-            reload(clc_group_fact)
-            ClcGroupFact(self.module)
-        # Assert Expected Behavior
-        self.module.fail_json.assert_called_with(
-            msg='requests library is required for this module')
-
-        # Reset
-        reload(clc_group_fact)
-
     def test_process_request(self):
         pass
 

--- a/tests/test_clc_server_fact.py
+++ b/tests/test_clc_server_fact.py
@@ -35,26 +35,6 @@ class TestClcServerFactFunctions(unittest.TestCase):
         self.module = mock.MagicMock()
         self.datacenter = mock.MagicMock()
 
-    def test_requests_module_not_found(self):
-        # Setup Mock Import Function
-        real_import = __import__
-
-        def mock_import(name, *args):
-            if name == 'requests':
-                args[0]['requests'].__version__ = '2.7.0'
-                raise ImportError
-            return real_import(name, *args)
-        # Under Test
-        with mock.patch('__builtin__.__import__', side_effect=mock_import):
-            reload(clc_server_fact)
-            ClcServerFact(self.module)
-        # Assert Expected Behavior
-        self.module.fail_json.assert_called_with(
-            msg='requests library is required for this module')
-
-        # Reset
-        reload(clc_server_fact)
-
     def test_process_request(self):
         pass
 


### PR DESCRIPTION
This PR is part of a larger effort to use native calls to the CLC API

The following changes to clc_group are part of this PR:
- Support for ansible 2.1
- Move CLC API authentication into common module
  - Module currently required to be installed on target machine (similar to clc_sdk)
  - Goal is to merge this in to ansible.module_utils
- Eliminate requests module in favor of ansible.module_utils.urls.url_open
- Eliminate use of clc_sdk within clc_group.py
- Determine if duplicate named groups exist, and inform the user of the group IDs

Similar changes to other modules will follow